### PR TITLE
Make the SWIG files compatible with SWIG 3

### DIFF
--- a/libapol/swig/apol.i
+++ b/libapol/swig/apol.i
@@ -256,7 +256,7 @@ uint8_t apol_str_to_protocol(const char *protocol_str);
 	}
 %}
 %extend apol_ip_t {
-	apol_ip_t(const char *str) {
+	apol_ip(const char *str) {
 		apol_ip_t *ip = NULL;
 		BEGIN_EXCEPTION
 		ip = calloc(1, sizeof(*ip));
@@ -274,7 +274,7 @@ uint8_t apol_str_to_protocol(const char *protocol_str);
 	fail:
 		return ip;
 	};
-	~apol_ip_t() {
+	~apol_ip() {
 	    free(self);
 	};
 	int get_protocol() {
@@ -303,31 +303,35 @@ char *apol_file_find_path(const char *file_name);
 %}
 typedef struct apol_vector {} apol_vector_t;
 %extend apol_vector_t {
-	apol_vector_t() {
+	apol_vector() {
 		return apol_vector_create(NULL);
 	};
-	apol_vector_t(qpol_iterator_t *iter) {
+	apol_vector(qpol_iterator_t *iter) {
 		return apol_vector_create_from_iter(iter, NULL);
 	};
-	apol_vector_t(apol_vector_t *v) {
+	apol_vector(apol_vector_t *v) {
 		return apol_vector_create_from_vector(v, NULL, NULL, NULL);
 	};
-	apol_vector_t(apol_vector_t *a, apol_vector_t *b) {
+	apol_vector(apol_vector_t *a, apol_vector_t *b) {
 		return apol_vector_create_from_intersection(a, b, NULL, NULL);
 	};
-	size_t get_size() {
+	%rename(get_size) wrap_get_size;
+	size_t wrap_get_size() {
 		return apol_vector_get_size(self);
 	};
-	size_t get_capacity() {
+	%rename(get_capacity) wrap_get_capacity;
+	size_t wrap_get_capacity() {
 		return apol_vector_get_capacity(self);
 	};
-	void *get_element(size_t i) {
+	%rename(get_element) wrap_get_element;
+	void *wrap_get_element(size_t i) {
 		return apol_vector_get_element(self, i);
 	};
-	~apol_vector_t() {
+	~apol_vector() {
 		apol_vector_destroy(&self);
 	};
-	void append(void *x) {
+	%rename(append) wrap_append;
+	void wrap_append(void *x) {
 		BEGIN_EXCEPTION
 		if (apol_vector_append(self, x)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -336,7 +340,8 @@ typedef struct apol_vector {} apol_vector_t;
 	fail:
 		return;
 	};
-	void append_unique(void *x) {
+	%rename(append_unique) wrap_append_unique;
+	void wrap_append_unique(void *x) {
 		BEGIN_EXCEPTION
 		if (apol_vector_append_unique(self, x, NULL, NULL)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -345,7 +350,8 @@ typedef struct apol_vector {} apol_vector_t;
 	fail:
 		return;
 	};
-	void cat(apol_vector_t *src) {
+	%rename(cat) wrap_cat;
+	void wrap_cat(apol_vector_t *src) {
 		BEGIN_EXCEPTION
 		if (apol_vector_cat(self, src)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -354,7 +360,8 @@ typedef struct apol_vector {} apol_vector_t;
 	fail:
 		return;
 	};
-	void remove(size_t idx) {
+	%rename(remove) wrap_remove;
+	void wrap_remove(size_t idx) {
 		BEGIN_EXCEPTION
 		if (apol_vector_remove(self, idx)) {
 			SWIG_exception(SWIG_RuntimeError, "Error removing vector element");
@@ -363,10 +370,12 @@ typedef struct apol_vector {} apol_vector_t;
 	fail:
 		return;
 	};
-	void sort() {
+	%rename(sort) wrap_sort;
+	void wrap_sort() {
 		apol_vector_sort(self, NULL, NULL);
 	};
-	void sort_uniquify() {
+	%rename(sort_uniquify) wrap_sort_uniquify;
+	void wrap_sort_uniquify() {
 		apol_vector_sort_uniquify(self, NULL, NULL);
 	};
 };
@@ -379,13 +388,13 @@ typedef struct apol_vector {} apol_vector_t;
 %}
 typedef struct apol_string_vector {} apol_string_vector_t;
 %extend apol_string_vector_t {
-	apol_string_vector_t() {
+	apol_string_vector() {
 		return (apol_string_vector_t*)apol_vector_create(free);
 	};
-	apol_string_vector_t(apol_string_vector_t *v) {
+	apol_string_vector(apol_string_vector_t *v) {
 		return (apol_string_vector_t*)apol_vector_create_from_vector((apol_vector_t*)v, apol_str_strdup, NULL, free);
 	};
-	apol_string_vector_t(apol_string_vector_t *a, apol_string_vector_t *b) {
+	apol_string_vector(apol_string_vector_t *a, apol_string_vector_t *b) {
 		return (apol_string_vector_t*)apol_vector_create_from_intersection((apol_vector_t*)a, (apol_vector_t*)b, apol_str_strcmp, NULL);
 	};
 	size_t get_size() {
@@ -397,7 +406,7 @@ typedef struct apol_string_vector {} apol_string_vector_t;
 	char *get_element(size_t i) {
 		return (char*)apol_vector_get_element((apol_vector_t*)self, i);
 	};
-	~apol_string_vector_t() {
+	~apol_string_vector() {
 		apol_vector_destroy((apol_vector_t**)&self);
 	};
 	size_t get_index(char *str) {
@@ -462,7 +471,7 @@ typedef struct apol_string_vector {} apol_string_vector_t;
 } apol_policy_path_type_e;
 typedef struct apol_policy_path {} apol_policy_path_t;
 %extend apol_policy_path_t {
-	apol_policy_path_t(apol_policy_path_type_e type, char * primary, apol_string_vector_t *modules = NULL) {
+	apol_policy_path(apol_policy_path_type_e type, char * primary, apol_string_vector_t *modules = NULL) {
 		apol_policy_path_t *p;
 		BEGIN_EXCEPTION
 		if ((p = apol_policy_path_create(type, primary,	(apol_vector_t*)modules)) == NULL) {
@@ -472,7 +481,7 @@ typedef struct apol_policy_path {} apol_policy_path_t;
 	fail:
 		return p;
 	};
-	apol_policy_path_t(char *path) {
+	apol_policy_path(char *path) {
 		apol_policy_path_t *p;
 		BEGIN_EXCEPTION
 		if ((p = apol_policy_path_create_from_file(path)) == NULL) {
@@ -482,7 +491,7 @@ typedef struct apol_policy_path {} apol_policy_path_t;
 	fail:
 		return p;
 	};
-	apol_policy_path_t(char *str, int unused) {
+	apol_policy_path(char *str, int unused) {
 		apol_policy_path_t *p;
 		BEGIN_EXCEPTION
 		if ((p = apol_policy_path_create_from_string(str)) == NULL) {
@@ -492,7 +501,7 @@ typedef struct apol_policy_path {} apol_policy_path_t;
 	fail:
 			return p;
 	};
-	apol_policy_path_t(apol_policy_path_t *in) {
+	apol_policy_path(apol_policy_path_t *in) {
 		apol_policy_path_t *p;
 		BEGIN_EXCEPTION
 		if ((p = apol_policy_path_create_from_policy_path(in)) == NULL) {
@@ -502,20 +511,24 @@ typedef struct apol_policy_path {} apol_policy_path_t;
 	fail:
 		return p;
 	};
-	~apol_policy_path_t() {
+	~apol_policy_path() {
 		apol_policy_path_destroy(&self);
 	};
-	apol_policy_path_type_e get_type() {
+	%rename(get_type) wrap_get_type;
+	apol_policy_path_type_e wrap_get_type() {
 		return apol_policy_path_get_type(self);
 	};
-	const char *get_primary() {
+	%rename(get_primary) wrap_get_primary;
+	const char *wrap_get_primary() {
 		return apol_policy_path_get_primary(self);
 	};
-	const apol_string_vector_t *get_modules() {
+	%rename(get_modules) wrap_get_modules;
+	const apol_string_vector_t *wrap_get_modules() {
 		return (apol_string_vector_t*)apol_policy_path_get_modules(self);
 	};
 	%newobject to_string();
-	char *to_string() {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string() {
 		char *str;
 		BEGIN_EXCEPTION
 		str = apol_policy_path_to_string(self);
@@ -526,7 +539,8 @@ typedef struct apol_policy_path {} apol_policy_path_t;
 	fail:
 		return str;
 	};
-	void to_file(char *path) {
+	%rename(to_file) wrap_to_file;
+	void wrap_to_file(char *path) {
 		BEGIN_EXCEPTION
 		if (apol_policy_path_to_file(self, path)) {
 			SWIG_exception(SWIG_RuntimeError, "Input/outpet error");
@@ -549,7 +563,7 @@ typedef struct apol_policy {} apol_policy_t;
 #define APOL_PERMMAP_BOTH	(APOL_PERMMAP_READ | APOL_PERMMAP_WRITE)
 #define APOL_PERMMAP_NONE	0x10
 %extend apol_policy_t {
-	apol_policy_t(apol_policy_path_t *path, int options = 0) {
+	apol_policy(apol_policy_path_t *path, int options = 0) {
 		apol_policy_t *p;
 		BEGIN_EXCEPTION
 		p = apol_policy_create_from_policy_path(path, options, apol_swig_message_callback, apol_swig_message_callback_arg);
@@ -564,25 +578,30 @@ typedef struct apol_policy {} apol_policy_t;
 	fail:
 		return p;
 	};
-	~apol_policy_t() {
+	~apol_policy() {
 		apol_policy_destroy(&self);
 	};
-	int get_policy_type() {
+	%rename(get_policy_type) wrap_get_policy_type;
+	int wrap_get_policy_type() {
 		return apol_policy_get_policy_type(self);
 	};
 
-	int get_policy_handle_unknown() {
+	%rename(get_policy_handle_unknown) wrap_get_policy_handle_unknown;
+	int wrap_get_policy_handle_unknown() {
 		return apol_policy_get_policy_handle_unknown(self);
 	};
 
-	qpol_policy_t *get_qpol() {
+	%rename(get_qpol) wrap_get_qpol;
+	qpol_policy_t *wrap_get_qpol() {
 		return apol_policy_get_qpol(self);
 	};
-	int is_mls() {
+	%rename(is_mls) wrap_is_mls;
+	int wrap_is_mls() {
 		return apol_policy_is_mls(self);
 	};
 	%newobject get_version_type_mls_str();
-	char *get_version_type_mls_str() {
+	%rename(get_version_type_mls_str) wrap_get_version_type_mls_str;
+	char *wrap_get_version_type_mls_str() {
 		char *str;
 		BEGIN_EXCEPTION
 		str = apol_policy_get_version_type_mls_str(self);
@@ -593,7 +612,8 @@ typedef struct apol_policy {} apol_policy_t;
 	fail:
 		return str;
 	};
-	void open_permmap(const char *path) {
+	%rename(open_permmap) wrap_open_permmap;
+	void wrap_open_permmap(const char *path) {
 		BEGIN_EXCEPTION
 		if (apol_policy_open_permmap(self, path) < 0) {
 			SWIG_exception(SWIG_RuntimeError, "Error loading permission map");
@@ -602,7 +622,8 @@ typedef struct apol_policy {} apol_policy_t;
 	fail:
 		return;
 	};
-	void save_permmap(const char *path) {
+	%rename(save_permmap) wrap_save_permmap;
+	void wrap_save_permmap(const char *path) {
 		BEGIN_EXCEPTION
 		if (apol_policy_save_permmap(self, path)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not save permission map");
@@ -631,7 +652,8 @@ typedef struct apol_policy {} apol_policy_t;
 	fail:
 		return dir;
 	};
-	void set_permmap(const char *class_name, const char *perm_name, int direction, int weight) {
+	%rename(set_permmap) wrap_set_permmap;
+	void wrap_set_permmap(const char *class_name, const char *perm_name, int direction, int weight) {
 		BEGIN_EXCEPTION
 		if (apol_policy_set_permmap(self, class_name, perm_name, direction, weight)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set permission mapping");
@@ -640,7 +662,8 @@ typedef struct apol_policy {} apol_policy_t;
 	fail:
 		return;
 	};
-	void build_domain_trans_table() {
+	%rename(build_domain_trans_table) wrap_build_domain_trans_table;
+	void wrap_build_domain_trans_table() {
 		BEGIN_EXCEPTION
 		if (apol_policy_build_domain_trans_table(self)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not build domain transition table");
@@ -649,7 +672,8 @@ typedef struct apol_policy {} apol_policy_t;
 	fail:
 		return;
 	};
-	void reset_domain_trans_table() {
+	%rename(reset_domain_trans_table) wrap_reset_domain_trans_table;
+	void wrap_reset_domain_trans_table() {
 		apol_policy_reset_domain_trans_table(self);
 	}
 };
@@ -657,7 +681,7 @@ typedef struct apol_policy {} apol_policy_t;
 /* apol type query */
 typedef struct apol_type_query {} apol_type_query_t;
 %extend apol_type_query_t {
-	apol_type_query_t() {
+	apol_type_query() {
 		apol_type_query_t *tq;
 		BEGIN_EXCEPTION
 		tq = apol_type_query_create();
@@ -668,7 +692,7 @@ typedef struct apol_type_query {} apol_type_query_t;
 	fail:
 		return tq;
 	};
-	~apol_type_query_t() {
+	~apol_type_query() {
 		apol_type_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t *);
@@ -682,7 +706,8 @@ typedef struct apol_type_query {} apol_type_query_t;
 	fail:
 		return v;
 	};
-	void set_type(apol_policy_t *p, char *name) {
+	%rename(set_type) wrap_set_type;
+	void wrap_set_type(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_type_query_set_type(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -691,7 +716,8 @@ typedef struct apol_type_query {} apol_type_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_type_query_set_regex(p, self, regex);
 	};
 };
@@ -699,7 +725,7 @@ typedef struct apol_type_query {} apol_type_query_t;
 /* apol attribute query */
 typedef struct apol_attr_query {} apol_attr_query_t;
 %extend apol_attr_query_t {
-	apol_attr_query_t() {
+	apol_attr_query() {
 		apol_attr_query_t *aq;
 		BEGIN_EXCEPTION
 		aq = apol_attr_query_create();
@@ -710,7 +736,7 @@ typedef struct apol_attr_query {} apol_attr_query_t;
 	fail:
 		return aq;
 	};
-	~apol_attr_query_t() {
+	~apol_attr_query() {
 		apol_attr_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t *);
@@ -724,7 +750,8 @@ typedef struct apol_attr_query {} apol_attr_query_t;
 	fail:
 		return v;
 	};
-	void set_attr(apol_policy_t *p, char *name) {
+	%rename(set_attr) wrap_set_attr;
+	void wrap_set_attr(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_attr_query_set_attr(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -733,7 +760,8 @@ typedef struct apol_attr_query {} apol_attr_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_attr_query_set_regex(p, self, regex);
 	};
 };
@@ -741,7 +769,7 @@ typedef struct apol_attr_query {} apol_attr_query_t;
 /* apol role query */
 typedef struct apol_role_query {} apol_role_query_t;
 %extend apol_role_query_t {
-	apol_role_query_t() {
+	apol_role_query() {
 		apol_role_query_t *rq;
 		BEGIN_EXCEPTION
 		rq = apol_role_query_create();
@@ -752,7 +780,7 @@ typedef struct apol_role_query {} apol_role_query_t;
 	fail:
 		return rq;
 	};
-	~apol_role_query_t() {
+	~apol_role_query() {
 		apol_role_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t *);
@@ -766,7 +794,8 @@ typedef struct apol_role_query {} apol_role_query_t;
 	fail:
 		return v;
 	};
-	void set_role(apol_policy_t *p, char *name) {
+	%rename(set_role) wrap_set_role;
+	void wrap_set_role(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_role_query_set_role(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -775,7 +804,8 @@ typedef struct apol_role_query {} apol_role_query_t;
 	fail:
 		return;
 	};
-	void set_type(apol_policy_t *p, char *name) {
+	%rename(set_type) wrap_set_type;
+	void wrap_set_type(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_role_query_set_type(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -784,7 +814,8 @@ typedef struct apol_role_query {} apol_role_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_role_query_set_regex(p, self, regex);
 	};
 };
@@ -793,7 +824,7 @@ int apol_role_has_type(apol_policy_t * p, qpol_role_t * r, qpol_type_t * t);
 /* apol class query */
 typedef struct apol_class_query {} apol_class_query_t;
 %extend apol_class_query_t {
-	apol_class_query_t() {
+	apol_class_query() {
 		apol_class_query_t *cq;
 		BEGIN_EXCEPTION
 		cq = apol_class_query_create();
@@ -804,7 +835,7 @@ typedef struct apol_class_query {} apol_class_query_t;
 	fail:
 		return cq;
 	};
-	~apol_class_query_t() {
+	~apol_class_query() {
 		apol_class_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -818,7 +849,8 @@ typedef struct apol_class_query {} apol_class_query_t;
 	fail:
 		return v;
 	};
-	void set_class(apol_policy_t *p, char *name) {
+	%rename(set_class) wrap_set_class;
+	void wrap_set_class(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_class_query_set_class(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -827,7 +859,8 @@ typedef struct apol_class_query {} apol_class_query_t;
 	fail:
 		return;
 	};
-	void set_common(apol_policy_t *p, char *name) {
+	%rename(set_common) wrap_set_common;
+	void wrap_set_common(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_class_query_set_common(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -836,7 +869,8 @@ typedef struct apol_class_query {} apol_class_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_class_query_set_regex(p, self, regex);
 	};
 };
@@ -844,7 +878,7 @@ typedef struct apol_class_query {} apol_class_query_t;
 /* apol common query */
 typedef struct apol_common_query {} apol_common_query_t;
 %extend apol_common_query_t {
-	apol_common_query_t() {
+	apol_common_query() {
 		apol_common_query_t *cq;
 		BEGIN_EXCEPTION
 		cq = apol_common_query_create();
@@ -855,7 +889,7 @@ typedef struct apol_common_query {} apol_common_query_t;
 	fail:
 		return cq;
 	};
-	~apol_common_query_t() {
+	~apol_common_query() {
 		apol_common_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -869,7 +903,8 @@ typedef struct apol_common_query {} apol_common_query_t;
 	fail:
 		return v;
 	};
-	void set_common(apol_policy_t *p, char *name) {
+	%rename(set_common) wrap_set_common;
+	void wrap_set_common(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_common_query_set_common(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -878,7 +913,8 @@ typedef struct apol_common_query {} apol_common_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_common_query_set_regex(p, self, regex);
 	};
 };
@@ -886,7 +922,7 @@ typedef struct apol_common_query {} apol_common_query_t;
 /* apol perm query */
 typedef struct apol_perm_query {} apol_perm_query_t;
 %extend apol_perm_query_t {
-	apol_perm_query_t() {
+	apol_perm_query() {
 		apol_perm_query_t *pq;
 		BEGIN_EXCEPTION
 		pq = apol_perm_query_create();
@@ -897,7 +933,7 @@ typedef struct apol_perm_query {} apol_perm_query_t;
 	fail:
 		return pq;
 	};
-	~apol_perm_query_t() {
+	~apol_perm_query() {
 		apol_perm_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -911,7 +947,8 @@ typedef struct apol_perm_query {} apol_perm_query_t;
 	fail:
 		return (apol_string_vector_t*)v;
 	};
-	void set_perm(apol_policy_t *p, char *name) {
+	%rename(set_perm) wrap_set_perm;
+	void wrap_set_perm(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_perm_query_set_perm(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -920,7 +957,8 @@ typedef struct apol_perm_query {} apol_perm_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_perm_query_set_regex(p, self, regex);
 	};
 };
@@ -928,7 +966,7 @@ typedef struct apol_perm_query {} apol_perm_query_t;
 /* apol bool query */
 typedef struct apol_bool_query {} apol_bool_query_t;
 %extend apol_bool_query_t {
-	apol_bool_query_t() {
+	apol_bool_query() {
 		apol_bool_query_t *bq;
 		BEGIN_EXCEPTION
 		bq = apol_bool_query_create();
@@ -939,7 +977,7 @@ typedef struct apol_bool_query {} apol_bool_query_t;
 	fail:
 		return bq;
 	};
-	~apol_bool_query_t() {
+	~apol_bool_query() {
 		apol_bool_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -953,7 +991,8 @@ typedef struct apol_bool_query {} apol_bool_query_t;
 	fail:
 		return v;
 	};
-	void set_bool(apol_policy_t *p, char *name) {
+	%rename(set_bool) wrap_set_bool;
+	void wrap_set_bool(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_bool_query_set_bool(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -962,7 +1001,8 @@ typedef struct apol_bool_query {} apol_bool_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_bool_query_set_regex(p, self, regex);
 	};
 };
@@ -970,7 +1010,7 @@ typedef struct apol_bool_query {} apol_bool_query_t;
 /* apol mls level */
 typedef struct apol_mls_level {} apol_mls_level_t;
 %extend apol_mls_level_t {
-	apol_mls_level_t() {
+	apol_mls_level() {
 		apol_mls_level_t *aml;
 		BEGIN_EXCEPTION
 		aml = apol_mls_level_create();
@@ -981,7 +1021,7 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 	fail:
 		return aml;
 	};
-	apol_mls_level_t(apol_mls_level_t *in) {
+	apol_mls_level(apol_mls_level_t *in) {
 		apol_mls_level_t *aml;
 		BEGIN_EXCEPTION
 		aml = apol_mls_level_create_from_mls_level(in);
@@ -992,7 +1032,7 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 	fail:
 		return aml;
 	};
-	apol_mls_level_t(apol_policy_t *p, const char *str) {
+	apol_mls_level(apol_policy_t *p, const char *str) {
 		apol_mls_level_t *aml;
 		BEGIN_EXCEPTION
 		aml = apol_mls_level_create_from_string(p, str);
@@ -1003,7 +1043,7 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 	fail:
 		return aml;
 	};
-	apol_mls_level_t(const char *str) {
+	apol_mls_level(const char *str) {
 		apol_mls_level_t *aml;
 		BEGIN_EXCEPTION
 		aml = apol_mls_level_create_from_literal(str);
@@ -1014,7 +1054,7 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 	fail:
 		return aml;
 	};
-	apol_mls_level_t(apol_policy_t *p, qpol_mls_level_t *qml) {
+	apol_mls_level(apol_policy_t *p, qpol_mls_level_t *qml) {
 		apol_mls_level_t *aml;
 		BEGIN_EXCEPTION
 		aml = apol_mls_level_create_from_qpol_mls_level(p, qml);
@@ -1025,7 +1065,7 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 	fail:
 		return aml;
 	};
-	apol_mls_level_t(apol_policy_t *p, qpol_level_t *ql) {
+	apol_mls_level(apol_policy_t *p, qpol_level_t *ql) {
 		apol_mls_level_t *aml;
 		BEGIN_EXCEPTION
 		aml = apol_mls_level_create_from_qpol_level_datum(p, ql);
@@ -1036,10 +1076,11 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 	fail:
 		return aml;
 	};
-	~apol_mls_level_t() {
+	~apol_mls_level() {
 		apol_mls_level_destroy(&self);
 	};
-	void set_sens(apol_policy_t *p, char *sens) {
+	%rename(set_sens) wrap_set_sens;
+	void wrap_set_sens(apol_policy_t *p, char *sens) {
 		BEGIN_EXCEPTION
 		if (apol_mls_level_set_sens(p, self, sens)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set level sensitivity");
@@ -1048,10 +1089,12 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 	fail:
 		return;
 	};
-	const char *get_sens() {
+	%rename(get_sens) wrap_get_sens;
+	const char *wrap_get_sens() {
 		return apol_mls_level_get_sens(self);
 	};
-	void append_cats(apol_policy_t *p, char *cats) {
+	%rename(append_cats) wrap_append_cats;
+	void wrap_append_cats(apol_policy_t *p, char *cats) {
 		BEGIN_EXCEPTION
 		if (apol_mls_level_append_cats(p, self, cats)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append level category");
@@ -1060,10 +1103,12 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 	fail:
 		return;
 	};
-	const apol_string_vector_t *get_cats() {
+	%rename(get_cats) wrap_get_cats;
+	const apol_string_vector_t *wrap_get_cats() {
 		return (apol_string_vector_t *) apol_mls_level_get_cats(self);
 	};
-	int validate(apol_policy_t *p) {
+	%rename(validate) wrap_validate;
+	int wrap_validate(apol_policy_t *p) {
 		int ret = -1;
 		BEGIN_EXCEPTION
 		ret = apol_mls_level_validate(p, self);
@@ -1075,7 +1120,8 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 		return ret;
 	}
 	%newobject render(apol_policy_t*);
-	char *render(apol_policy_t *p) {
+	%rename(render) wrap_render;
+	char *wrap_render(apol_policy_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = apol_mls_level_render(p, self);
@@ -1086,7 +1132,8 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 	fail:
 		return str;
 	};
-	int convert(apol_policy_t *p) {
+	%rename(convert) wrap_convert;
+	int wrap_convert(apol_policy_t *p) {
 		int ret = -1;
 		BEGIN_EXCEPTION
 		ret = apol_mls_level_convert(p, self);
@@ -1097,7 +1144,8 @@ typedef struct apol_mls_level {} apol_mls_level_t;
 	fail:
 		return ret;
 	}
-	int is_literal() {
+	%rename(is_literal) wrap_is_literal;
+	int wrap_is_literal() {
 		int ret = -1;
 		BEGIN_EXCEPTION
 		ret = apol_mls_level_is_literal(self);
@@ -1133,7 +1181,7 @@ int apol_mls_cats_compare(apol_policy_t * p, const char *cat1, const char *cat2)
 #endif
 typedef struct apol_mls_range {} apol_mls_range_t;
 %extend apol_mls_range_t {
-	apol_mls_range_t() {
+	apol_mls_range() {
 		apol_mls_range_t *amr;
 		BEGIN_EXCEPTION
 		amr = apol_mls_range_create();
@@ -1144,7 +1192,7 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 	fail:
 		return amr;
 	};
-	apol_mls_range_t(apol_mls_range_t *in) {
+	apol_mls_range(apol_mls_range_t *in) {
 		apol_mls_range_t *amr;
 		BEGIN_EXCEPTION
 		amr = apol_mls_range_create_from_mls_range(in);
@@ -1155,7 +1203,7 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 	fail:
 		return amr;
 	};
-	apol_mls_range_t(apol_policy_t *p, const char *s) {
+	apol_mls_range(apol_policy_t *p, const char *s) {
 		apol_mls_range_t *amr;
 		BEGIN_EXCEPTION
 		amr = apol_mls_range_create_from_string(p, s);
@@ -1166,7 +1214,7 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 	fail:
 		return amr;
 	};
-	apol_mls_range_t(const char *s) {
+	apol_mls_range(const char *s) {
 		apol_mls_range_t *amr;
 		BEGIN_EXCEPTION
 		amr = apol_mls_range_create_from_literal(s);
@@ -1177,7 +1225,7 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 	fail:
 		return amr;
 	};
-	apol_mls_range_t(apol_policy_t *p, qpol_mls_range_t *in) {
+	apol_mls_range(apol_policy_t *p, qpol_mls_range_t *in) {
 		apol_mls_range_t *amr;
 		BEGIN_EXCEPTION
 		amr = apol_mls_range_create_from_qpol_mls_range(p, in);
@@ -1188,10 +1236,11 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 	fail:
 		return amr;
 	};
-	~apol_mls_range_t() {
+	~apol_mls_range() {
 		apol_mls_range_destroy(&self);
 	};
-	void set_low(apol_policy_t *p, apol_mls_level_t *lvl) {
+	%rename(set_low) wrap_set_low;
+	void wrap_set_low(apol_policy_t *p, apol_mls_level_t *lvl) {
 		BEGIN_EXCEPTION
 		if (apol_mls_range_set_low(p, self, lvl)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set low level");
@@ -1200,7 +1249,8 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 	fail:
 		return;
 	};
-	void set_high(apol_policy_t *p, apol_mls_level_t *lvl) {
+	%rename(set_high) wrap_set_high;
+	void wrap_set_high(apol_policy_t *p, apol_mls_level_t *lvl) {
 		BEGIN_EXCEPTION
 		if (apol_mls_range_set_high(p, self, lvl)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set high level");
@@ -1209,14 +1259,17 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 	fail:
 			return;
 	};
-	const apol_mls_level_t *get_low() {
+	%rename(get_low) wrap_get_low;
+	const apol_mls_level_t *wrap_get_low() {
 		return apol_mls_range_get_low(self);
 	}
-	const apol_mls_level_t *get_high() {
+	%rename(get_high) wrap_get_high;
+	const apol_mls_level_t *wrap_get_high() {
 		return apol_mls_range_get_high(self);
 	}
 	%newobject render(apol_policy_t*);
-	char *render(apol_policy_t *p) {
+	%rename(render) wrap_render;
+	char *wrap_render(apol_policy_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = apol_mls_range_render(p, self);
@@ -1228,7 +1281,8 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 		return str;
 	};
 	%newobject get_levels(apol_policy_t*);
-	apol_vector_t *get_levels(apol_policy_t *p) {
+	%rename(get_levels) wrap_get_levels;
+	apol_vector_t *wrap_get_levels(apol_policy_t *p) {
 		apol_vector_t *v;
 		BEGIN_EXCEPTION
 		v = apol_mls_range_get_levels(p, self);
@@ -1239,7 +1293,8 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 	fail:
 			return v;
 	};
-	int validate(apol_policy_t *p) {
+	%rename(validate) wrap_validate;
+	int wrap_validate(apol_policy_t *p) {
 		int ret = apol_mls_range_validate(p, self);
 		BEGIN_EXCEPTION
 		if (ret < 0) {
@@ -1249,7 +1304,8 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 	fail:
 		return ret;
 	}
-	int is_literal() {
+	%rename(is_literal) wrap_is_literal;
+	int wrap_is_literal() {
 		int ret = -1;
 		BEGIN_EXCEPTION
 		ret = apol_mls_range_is_literal(self);
@@ -1260,7 +1316,8 @@ typedef struct apol_mls_range {} apol_mls_range_t;
 	fail:
 		return ret;
 	}
-	int convert(apol_policy_t *p) {
+	%rename(convert) wrap_convert;
+	int wrap_convert(apol_policy_t *p) {
 		int ret = -1;
 		BEGIN_EXCEPTION
 		ret = apol_mls_range_convert(p, self);
@@ -1283,7 +1340,7 @@ int apol_mls_range_contain_subrange(apol_policy_t * p, const apol_mls_range_t * 
 /* apol level query */
 typedef struct apol_level_query {} apol_level_query_t;
 %extend apol_level_query_t {
-	apol_level_query_t() {
+	apol_level_query() {
 		apol_level_query_t * alq;
 		BEGIN_EXCEPTION
 		alq = apol_level_query_create();
@@ -1294,7 +1351,7 @@ typedef struct apol_level_query {} apol_level_query_t;
 	fail:
 		return alq;
 	};
-	~apol_level_query_t() {
+	~apol_level_query() {
 		apol_level_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -1308,7 +1365,8 @@ typedef struct apol_level_query {} apol_level_query_t;
 	fail:
 		return v;
 	};
-	void set_sens(apol_policy_t *p, char *name) {
+	%rename(set_sens) wrap_set_sens;
+	void wrap_set_sens(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_level_query_set_sens(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1317,7 +1375,8 @@ typedef struct apol_level_query {} apol_level_query_t;
 	fail:
 		return;
 	};
-	void set_cat(apol_policy_t *p, char *name) {
+	%rename(set_cat) wrap_set_cat;
+	void wrap_set_cat(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_level_query_set_cat(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1326,7 +1385,8 @@ typedef struct apol_level_query {} apol_level_query_t;
 	fail:
 			return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_level_query_set_regex(p, self, regex);
 	};
 };
@@ -1334,7 +1394,7 @@ typedef struct apol_level_query {} apol_level_query_t;
 /* apol cat query */
 typedef struct apol_cat_query {} apol_cat_query_t;
 %extend apol_cat_query_t {
-	apol_cat_query_t() {
+	apol_cat_query() {
 		apol_cat_query_t * acq;
 		BEGIN_EXCEPTION
 		acq = apol_cat_query_create();
@@ -1345,7 +1405,7 @@ typedef struct apol_cat_query {} apol_cat_query_t;
 	fail:
 		return acq;
 	};
-	~apol_cat_query_t() {
+	~apol_cat_query() {
 		apol_cat_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t *);
@@ -1359,7 +1419,8 @@ typedef struct apol_cat_query {} apol_cat_query_t;
 	fail:
 		return v;
 	};
-	void set_cat(apol_policy_t *p, char *name) {
+	%rename(set_cat) wrap_set_cat;
+	void wrap_set_cat(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_cat_query_set_cat(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1368,7 +1429,8 @@ typedef struct apol_cat_query {} apol_cat_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_cat_query_set_regex(p, self, regex);
 	};
 };
@@ -1384,7 +1446,7 @@ typedef struct apol_cat_query {} apol_cat_query_t;
 #endif
 typedef struct apol_user_query {} apol_user_query_t;
 %extend apol_user_query_t {
-	apol_user_query_t() {
+	apol_user_query() {
 		apol_user_query_t *auq;
 		BEGIN_EXCEPTION
 		auq = apol_user_query_create();
@@ -1395,7 +1457,7 @@ typedef struct apol_user_query {} apol_user_query_t;
 	fail:
 		return auq;
 	};
-	~apol_user_query_t() {
+	~apol_user_query() {
 		apol_user_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -1409,7 +1471,8 @@ typedef struct apol_user_query {} apol_user_query_t;
 	fail:
 		return v;
 	};
-	void set_user(apol_policy_t *p, char *name) {
+	%rename(set_user) wrap_set_user;
+	void wrap_set_user(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_user_query_set_user(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1418,7 +1481,8 @@ typedef struct apol_user_query {} apol_user_query_t;
 	fail:
 		return;
 	};
-	void set_role(apol_policy_t *p, char *name) {
+	%rename(set_role) wrap_set_role;
+	void wrap_set_role(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_user_query_set_role(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1427,7 +1491,8 @@ typedef struct apol_user_query {} apol_user_query_t;
 	fail:
 		return;
 	};
-	void set_default_level(apol_policy_t *p, apol_mls_level_t *lvl) {
+	%rename(set_default_level) wrap_set_default_level;
+	void wrap_set_default_level(apol_policy_t *p, apol_mls_level_t *lvl) {
 		BEGIN_EXCEPTION
 		if (apol_user_query_set_default_level(p, self, lvl)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1436,7 +1501,8 @@ typedef struct apol_user_query {} apol_user_query_t;
 	fail:
 		return;
 	};
-	void set_range(apol_policy_t *p, apol_mls_range_t *rng, int range_match) {
+	%rename(set_range) wrap_set_range;
+	void wrap_set_range(apol_policy_t *p, apol_mls_range_t *rng, int range_match) {
 		BEGIN_EXCEPTION
 		if (apol_user_query_set_range(p, self, rng, range_match)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1445,7 +1511,8 @@ typedef struct apol_user_query {} apol_user_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_user_query_set_regex(p, self, regex);
 	};
 };
@@ -1453,7 +1520,7 @@ typedef struct apol_user_query {} apol_user_query_t;
 /* apol context */
 typedef struct apol_context {} apol_context_t;
 %extend apol_context_t {
-	apol_context_t() {
+	apol_context() {
 		apol_context_t *ctx;
 		BEGIN_EXCEPTION
 		ctx = apol_context_create();
@@ -1464,7 +1531,7 @@ typedef struct apol_context {} apol_context_t;
 	fail:
 		return ctx;
 	};
-	apol_context_t(apol_policy_t *p, qpol_context_t *in) {
+	apol_context(apol_policy_t *p, qpol_context_t *in) {
 		apol_context_t *ctx;
 		BEGIN_EXCEPTION
 		ctx = apol_context_create_from_qpol_context(p, in);
@@ -1475,7 +1542,7 @@ typedef struct apol_context {} apol_context_t;
 	fail:
 		return ctx;
 	};
-	apol_context_t(const char *str) {
+	apol_context(const char *str) {
 		apol_context_t *ctx;
 		BEGIN_EXCEPTION
 		ctx = apol_context_create_from_literal(str);
@@ -1486,10 +1553,11 @@ typedef struct apol_context {} apol_context_t;
 	fail:
 		return ctx;
 	};
-	~apol_context_t() {
+	~apol_context() {
 		apol_context_destroy(&self);
 	};
-	void set_user(apol_policy_t *p, char *name) {
+	%rename(set_user) wrap_set_user;
+	void wrap_set_user(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_context_set_user(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1498,10 +1566,12 @@ typedef struct apol_context {} apol_context_t;
 	fail:
 		return;
 	};
-	const char *get_user() {
+	%rename(get_user) wrap_get_user;
+	const char *wrap_get_user() {
 		return apol_context_get_user(self);
 	};
-	void set_role(apol_policy_t *p, char *name) {
+	%rename(set_role) wrap_set_role;
+	void wrap_set_role(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_context_set_role(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1510,10 +1580,12 @@ typedef struct apol_context {} apol_context_t;
 	fail:
 		return;
 	};
-	const char *get_role() {
+	%rename(get_role) wrap_get_role;
+	const char *wrap_get_role() {
 		return apol_context_get_role(self);
 	};
-	void set_type(apol_policy_t *p, char *name) {
+	%rename(set_type) wrap_set_type;
+	void wrap_set_type(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_context_set_type(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1522,10 +1594,12 @@ typedef struct apol_context {} apol_context_t;
 	fail:
 		return;
 	};
-	const char *get_type() {
+	%rename(get_type) wrap_get_type;
+	const char *wrap_get_type() {
 		return apol_context_get_type(self);
 	};
-	void set_range(apol_policy_t *p, apol_mls_range_t *rng) {
+	%rename(set_range) wrap_set_range;
+	void wrap_set_range(apol_policy_t *p, apol_mls_range_t *rng) {
 		BEGIN_EXCEPTION
 		if (apol_context_set_range(p, self, rng)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1534,10 +1608,12 @@ typedef struct apol_context {} apol_context_t;
 	fail:
 		return;
 	};
-	const apol_mls_range_t *get_range() {
+	%rename(get_range) wrap_get_range;
+	const apol_mls_range_t *wrap_get_range() {
 		return apol_context_get_range(self);
 	};
-	int validate(apol_policy_t *p) {
+	%rename(validate) wrap_validate;
+	int wrap_validate(apol_policy_t *p) {
 		int ret = -1;
 		BEGIN_EXCEPTION
 		ret = apol_context_validate(p, self);
@@ -1548,7 +1624,8 @@ typedef struct apol_context {} apol_context_t;
 	fail:
 		return ret;
 	}
-	int validate_partial(apol_policy_t *p) {
+	%rename(validate_partial) wrap_validate_partial;
+	int wrap_validate_partial(apol_policy_t *p) {
 		int ret = -1;
 		BEGIN_EXCEPTION
 		ret = apol_context_validate_partial(p, self);
@@ -1560,7 +1637,8 @@ typedef struct apol_context {} apol_context_t;
 		return ret;
 	}
 	%newobject render(apol_policy_t*);
-	char *render(apol_policy_t *p) {
+	%rename(render) wrap_render;
+	char *wrap_render(apol_policy_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = apol_context_render(p, self);
@@ -1571,7 +1649,8 @@ typedef struct apol_context {} apol_context_t;
 	fail:
 		return str;
 	};
-	int convert(apol_policy_t *p) {
+	%rename(convert) wrap_convert;
+	int wrap_convert(apol_policy_t *p) {
 		int ret = -1;
 		BEGIN_EXCEPTION
 		ret = apol_context_convert(p, self);
@@ -1588,7 +1667,7 @@ int apol_context_compare(apol_policy_t * p, apol_context_t * target, apol_contex
 /* apol constraint query */
 typedef struct apol_constraint_query {} apol_constraint_query_t;
 %extend apol_constraint_query_t {
-	apol_constraint_query_t() {
+	apol_constraint_query() {
 		apol_constraint_query_t *acq;
 		BEGIN_EXCEPTION
 		acq = apol_constraint_query_create();
@@ -1599,7 +1678,7 @@ typedef struct apol_constraint_query {} apol_constraint_query_t;
 	fail:
 		return acq;
 	};
-	~apol_constraint_query_t() {
+	~apol_constraint_query() {
 		apol_constraint_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -1613,7 +1692,8 @@ typedef struct apol_constraint_query {} apol_constraint_query_t;
 	fail:
 		return v;
 	};
-	void set_class(apol_policy_t *p, char *name) {
+	%rename(set_class) wrap_set_class;
+	void wrap_set_class(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_constraint_query_set_class(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1622,7 +1702,8 @@ typedef struct apol_constraint_query {} apol_constraint_query_t;
 	fail:
 		return;
 	}
-	void set_perm(apol_policy_t *p, char *name) {
+	%rename(set_perm) wrap_set_perm;
+	void wrap_set_perm(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_constraint_query_set_perm(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1631,7 +1712,8 @@ typedef struct apol_constraint_query {} apol_constraint_query_t;
 	fail:
 		return;
 	}
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_constraint_query_set_regex(p, self, regex);
 	};
 };
@@ -1639,7 +1721,7 @@ typedef struct apol_constraint_query {} apol_constraint_query_t;
 /* apol validatetrans query */
 typedef struct apol_validatetrans_query {} apol_validatetrans_query_t;
 %extend apol_validatetrans_query_t {
-	apol_validatetrans_query_t() {
+	apol_validatetrans_query() {
 		apol_validatetrans_query_t *avq;
 		BEGIN_EXCEPTION
 		avq = apol_validatetrans_query_create();
@@ -1650,7 +1732,7 @@ typedef struct apol_validatetrans_query {} apol_validatetrans_query_t;
 	fail:
 		return avq;
 	};
-	~apol_validatetrans_query_t() {
+	~apol_validatetrans_query() {
 		apol_validatetrans_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -1664,7 +1746,8 @@ typedef struct apol_validatetrans_query {} apol_validatetrans_query_t;
 	fail:
 		return v;
 	};
-	void set_class(apol_policy_t *p, char *name) {
+	%rename(set_class) wrap_set_class;
+	void wrap_set_class(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_validatetrans_query_set_class(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1673,7 +1756,8 @@ typedef struct apol_validatetrans_query {} apol_validatetrans_query_t;
 	fail:
 		return;
 	}
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_validatetrans_query_set_regex(p, self, regex);
 	};
 };
@@ -1689,7 +1773,7 @@ typedef struct apol_validatetrans_query {} apol_validatetrans_query_t;
 #endif
 typedef struct apol_genfscon_query {} apol_genfscon_query_t;
 %extend apol_genfscon_query_t {
-	apol_genfscon_query_t() {
+	apol_genfscon_query() {
 		apol_genfscon_query_t *agq;
 		BEGIN_EXCEPTION
 		agq = apol_genfscon_query_create();
@@ -1700,7 +1784,7 @@ typedef struct apol_genfscon_query {} apol_genfscon_query_t;
 	fail:
 		return agq;
 	};
-	~apol_genfscon_query_t() {
+	~apol_genfscon_query() {
 		apol_genfscon_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -1714,7 +1798,8 @@ typedef struct apol_genfscon_query {} apol_genfscon_query_t;
 	fail:
 		return v;
 	};
-	void set_filesystem(apol_policy_t *p, char *fs) {
+	%rename(set_filesystem) wrap_set_filesystem;
+	void wrap_set_filesystem(apol_policy_t *p, char *fs) {
 		BEGIN_EXCEPTION
 		if (apol_genfscon_query_set_filesystem(p, self, fs)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1723,7 +1808,8 @@ typedef struct apol_genfscon_query {} apol_genfscon_query_t;
 	fail:
 		return;
 	};
-	void set_path(apol_policy_t *p, char *path) {
+	%rename(set_path) wrap_set_path;
+	void wrap_set_path(apol_policy_t *p, char *path) {
 		BEGIN_EXCEPTION
 		if (apol_genfscon_query_set_path(p, self, path)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1732,7 +1818,8 @@ typedef struct apol_genfscon_query {} apol_genfscon_query_t;
 	fail:
 		return;
 	};
-	void set_objclass(apol_policy_t *p, int objclass) {
+	%rename(set_objclass) wrap_set_objclass;
+	void wrap_set_objclass(apol_policy_t *p, int objclass) {
 		BEGIN_EXCEPTION
 		if (apol_genfscon_query_set_objclass(p, self, objclass)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set object class for genfscon query");
@@ -1741,7 +1828,8 @@ typedef struct apol_genfscon_query {} apol_genfscon_query_t;
 	fail:
 		return;
 	};
-	void set_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
+	%rename(set_context) wrap_set_context;
+	void wrap_set_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
 		apol_genfscon_query_set_context(p, self, ctx, range_match);
 	};
 };
@@ -1751,7 +1839,7 @@ char *apol_genfscon_render(apol_policy_t * p, qpol_genfscon_t * genfscon);
 /* apol fs_use query */
 typedef struct apol_fs_use_query {} apol_fs_use_query_t;
 %extend apol_fs_use_query_t {
-	apol_fs_use_query_t() {
+	apol_fs_use_query() {
 		apol_fs_use_query_t *afq;
 		BEGIN_EXCEPTION
 		afq = apol_fs_use_query_create();
@@ -1762,7 +1850,7 @@ typedef struct apol_fs_use_query {} apol_fs_use_query_t;
 	fail:
 		return afq;
 	};
-	~apol_fs_use_query_t() {
+	~apol_fs_use_query() {
 		apol_fs_use_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -1776,7 +1864,8 @@ typedef struct apol_fs_use_query {} apol_fs_use_query_t;
 	fail:
 		return v;
 	};
-	void set_filesystem(apol_policy_t *p, char *fs) {
+	%rename(set_filesystem) wrap_set_filesystem;
+	void wrap_set_filesystem(apol_policy_t *p, char *fs) {
 		BEGIN_EXCEPTION
 		if (apol_fs_use_query_set_filesystem(p, self, fs)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1785,7 +1874,8 @@ typedef struct apol_fs_use_query {} apol_fs_use_query_t;
 	fail:
 		return;
 	};
-	void set_behavior(apol_policy_t *p, int behavior) {
+	%rename(set_behavior) wrap_set_behavior;
+	void wrap_set_behavior(apol_policy_t *p, int behavior) {
 		BEGIN_EXCEPTION
 		if (apol_fs_use_query_set_behavior(p, self, behavior)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set behavior for fs_use query");
@@ -1794,7 +1884,8 @@ typedef struct apol_fs_use_query {} apol_fs_use_query_t;
 	fail:
 		return;
 	};
-	void set_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
+	%rename(set_context) wrap_set_context;
+	void wrap_set_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
 		apol_fs_use_query_set_context(p, self, ctx, range_match);
 	};
 };
@@ -1804,7 +1895,7 @@ char *apol_fs_use_render(apol_policy_t * p, qpol_fs_use_t * fsuse);
 /* apol initial sid query */
 typedef struct apol_isid_query {} apol_isid_query_t;
 %extend apol_isid_query_t {
-	apol_isid_query_t() {
+	apol_isid_query() {
 		apol_isid_query_t *aiq;
 		BEGIN_EXCEPTION
 		aiq = apol_isid_query_create();
@@ -1815,7 +1906,7 @@ typedef struct apol_isid_query {} apol_isid_query_t;
 	fail:
 		return aiq;
 	};
-	~apol_isid_query_t() {
+	~apol_isid_query() {
 		apol_isid_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -1829,7 +1920,8 @@ typedef struct apol_isid_query {} apol_isid_query_t;
 	fail:
 		return v;
 	};
-	void set_name(apol_policy_t *p, char *name) {
+	%rename(set_name) wrap_set_name;
+	void wrap_set_name(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_isid_query_set_name(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1838,7 +1930,8 @@ typedef struct apol_isid_query {} apol_isid_query_t;
 	fail:
 		return;
 	};
-	void set_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
+	%rename(set_context) wrap_set_context;
+	void wrap_set_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
 		apol_isid_query_set_context(p, self, ctx, range_match);
 	};
 };
@@ -1846,7 +1939,7 @@ typedef struct apol_isid_query {} apol_isid_query_t;
 /* apol portcon query */
 typedef struct apol_portcon_query {} apol_portcon_query_t;
 %extend apol_portcon_query_t {
-	apol_portcon_query_t() {
+	apol_portcon_query() {
 		apol_portcon_query_t *apq;
 		BEGIN_EXCEPTION
 		apq = apol_portcon_query_create();
@@ -1857,7 +1950,7 @@ typedef struct apol_portcon_query {} apol_portcon_query_t;
 	fail:
 		return apq;
 	};
-	~apol_portcon_query_t() {
+	~apol_portcon_query() {
 		apol_portcon_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -1871,16 +1964,20 @@ typedef struct apol_portcon_query {} apol_portcon_query_t;
 	fail:
 		return v;
 	};
-	void set_protocol(apol_policy_t *p, int protocol) {
+	%rename(set_protocol) wrap_set_protocol;
+	void wrap_set_protocol(apol_policy_t *p, int protocol) {
 		apol_portcon_query_set_protocol(p, self, protocol);
 	};
-	void set_low(apol_policy_t *p, int port) {
+	%rename(set_low) wrap_set_low;
+	void wrap_set_low(apol_policy_t *p, int port) {
 		apol_portcon_query_set_low(p, self, port);
 	};
-	void set_high(apol_policy_t *p, int port) {
+	%rename(set_high) wrap_set_high;
+	void wrap_set_high(apol_policy_t *p, int port) {
 		apol_portcon_query_set_high(p, self, port);
 	};
-	void set_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
+	%rename(set_context) wrap_set_context;
+	void wrap_set_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
 		apol_portcon_query_set_context(p, self, ctx, range_match);
 	};
 };
@@ -1889,8 +1986,9 @@ char *apol_portcon_render(apol_policy_t * p, qpol_portcon_t * portcon);
 
 /* apol netifcon query */
 typedef struct apol_netifcon_query {} apol_netifcon_query_t;
+%rename(apol_netifcon_query_set_msg_context) apol_netifcon_query_set_msg_context;
 %extend apol_netifcon_query_t {
-	apol_netifcon_query_t() {
+	apol_netifcon_query() {
 		apol_netifcon_query_t *anq;
 		BEGIN_EXCEPTION
 		anq = apol_netifcon_query_create();
@@ -1901,7 +1999,7 @@ typedef struct apol_netifcon_query {} apol_netifcon_query_t;
 	fail:
 		return anq;
 	};
-	~apol_netifcon_query_t() {
+	~apol_netifcon_query() {
 		apol_netifcon_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -1915,7 +2013,8 @@ typedef struct apol_netifcon_query {} apol_netifcon_query_t;
 	fail:
 		return v;
 	};
-	void set_device(apol_policy_t *p, char *name) {
+	%rename(set_device) wrap_set_device;
+	void wrap_set_device(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_netifcon_query_set_device(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -1924,10 +2023,12 @@ typedef struct apol_netifcon_query {} apol_netifcon_query_t;
 	fail:
 		return;
 	};
-	void set_if_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
+	%rename(set_if_context) wrap_set_if_context;
+	void wrap_set_if_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
 		apol_netifcon_query_set_if_context(p, self, ctx, range_match);
 	};
-	void set_msg_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
+	%rename(set_msg_context) wrap_set_msg_context;
+	void wrap_set_msg_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
 		apol_netifcon_query_set_msg_context(p, self, ctx, range_match);
 	};
 };
@@ -1937,7 +2038,7 @@ char *apol_netifcon_render(apol_policy_t * p, qpol_netifcon_t * netifcon);
 /* apol nodecon query */
 typedef struct apol_nodecon_query {} apol_nodecon_query_t;
 %extend apol_nodecon_query_t {
-	apol_nodecon_query_t() {
+	apol_nodecon_query() {
 		apol_nodecon_query_t *anq;
 		BEGIN_EXCEPTION
 		anq = apol_nodecon_query_create();
@@ -1948,7 +2049,7 @@ typedef struct apol_nodecon_query {} apol_nodecon_query_t;
 	fail:
 		return anq;
 	};
-	~apol_nodecon_query_t() {
+	~apol_nodecon_query() {
 		apol_nodecon_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -1962,7 +2063,8 @@ typedef struct apol_nodecon_query {} apol_nodecon_query_t;
 	fail:
 		return v;
 	};
-	void set_protocol(apol_policy_t *p, int protocol) {
+	%rename(set_protocol) wrap_set_protocol;
+	void wrap_set_protocol(apol_policy_t *p, int protocol) {
 		BEGIN_EXCEPTION
 		if (apol_nodecon_query_set_protocol(p, self, protocol)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set protocol for nodecon query");
@@ -2007,7 +2109,8 @@ typedef struct apol_nodecon_query {} apol_nodecon_query_t;
 	fail:
 		return;
 	};
-	void set_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
+	%rename(set_context) wrap_set_context;
+	void wrap_set_context(apol_policy_t *p, apol_context_t *ctx, int range_match) {
 		apol_nodecon_query_set_context(p, self, ctx, range_match);
 	};
 };
@@ -2017,7 +2120,7 @@ char *apol_nodecon_render(apol_policy_t * p, qpol_nodecon_t * nodecon);
 /* apol avrule query */
 typedef struct apol_avrule_query {} apol_avrule_query_t;
 %extend apol_avrule_query_t {
-	apol_avrule_query_t() {
+	apol_avrule_query() {
 		apol_avrule_query_t *avq;
 		BEGIN_EXCEPTION
 		avq = apol_avrule_query_create();
@@ -2028,7 +2131,7 @@ typedef struct apol_avrule_query {} apol_avrule_query_t;
 	fail:
 		return avq;
 	};
-	~apol_avrule_query_t() {
+	~apol_avrule_query() {
 		apol_avrule_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -2053,10 +2156,12 @@ typedef struct apol_avrule_query {} apol_avrule_query_t;
 	fail:
 		return v;
 	};
-	void set_rules(apol_policy_t *p, int rules) {
+	%rename(set_rules) wrap_set_rules;
+	void wrap_set_rules(apol_policy_t *p, int rules) {
 		apol_avrule_query_set_rules(p, self, rules);
 	};
-	void set_source(apol_policy_t *p, char *name, int indirect) {
+	%rename(set_source) wrap_set_source;
+	void wrap_set_source(apol_policy_t *p, char *name, int indirect) {
 		BEGIN_EXCEPTION
 		if (apol_avrule_query_set_source(p, self, name, indirect)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set source for avrule query");
@@ -2065,7 +2170,8 @@ typedef struct apol_avrule_query {} apol_avrule_query_t;
 	fail:
 		return;
 	};
-	void set_source_component(apol_policy_t *p, int component) {
+	%rename(set_source_component) wrap_set_source_component;
+	void wrap_set_source_component(apol_policy_t *p, int component) {
 		BEGIN_EXCEPTION
 		if (apol_avrule_query_set_source_component(p, self, component)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set source component for avrule query");
@@ -2074,7 +2180,8 @@ typedef struct apol_avrule_query {} apol_avrule_query_t;
 	fail:
 		return;
 	};
-	void set_target(apol_policy_t *p, char *name, int indirect) {
+	%rename(set_target) wrap_set_target;
+	void wrap_set_target(apol_policy_t *p, char *name, int indirect) {
 		BEGIN_EXCEPTION
 		if (apol_avrule_query_set_target(p, self, name, indirect)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set target for avrule query");
@@ -2083,7 +2190,8 @@ typedef struct apol_avrule_query {} apol_avrule_query_t;
 	fail:
 		return;
 	};
-	void set_target_component(apol_policy_t *p, int component) {
+	%rename(set_target_component) wrap_set_target_component;
+	void wrap_set_target_component(apol_policy_t *p, int component) {
 		BEGIN_EXCEPTION
 		if (apol_avrule_query_set_target_component(p, self, component)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set target component for avrule query");
@@ -2092,7 +2200,8 @@ typedef struct apol_avrule_query {} apol_avrule_query_t;
 	fail:
 		return;
 	};
-	void append_class(apol_policy_t *p, char *name) {
+	%rename(append_class) wrap_append_class;
+	void wrap_append_class(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_avrule_query_append_class(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append class to avrule query");
@@ -2101,7 +2210,8 @@ typedef struct apol_avrule_query {} apol_avrule_query_t;
 	fail:
 		return;
 	};
-	void append_perm(apol_policy_t *p, char *name) {
+	%rename(append_perm) wrap_append_perm;
+	void wrap_append_perm(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_avrule_query_append_perm(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append permission to avrule query");
@@ -2110,7 +2220,8 @@ typedef struct apol_avrule_query {} apol_avrule_query_t;
 	fail:
 		return;
 	};
-	void set_bool(apol_policy_t *p, char *name) {
+	%rename(set_bool) wrap_set_bool;
+	void wrap_set_bool(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_avrule_query_set_bool(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set boolean for avrule query");
@@ -2119,16 +2230,20 @@ typedef struct apol_avrule_query {} apol_avrule_query_t;
 	fail:
 		return;
 	};
-	void set_enabled(apol_policy_t *p, int enabled) {
+	%rename(set_enabled) wrap_set_enabled;
+	void wrap_set_enabled(apol_policy_t *p, int enabled) {
 		apol_avrule_query_set_enabled(p, self, enabled);
 	};
-	void set_all_perms(apol_policy_t *p, int all_perms) {
+	%rename(set_all_perms) wrap_set_all_perms;
+	void wrap_set_all_perms(apol_policy_t *p, int all_perms) {
 		apol_avrule_query_set_all_perms(p, self, all_perms);
 	};
-	void set_source_any(apol_policy_t *p, int is_any) {
+	%rename(set_source_any) wrap_set_source_any;
+	void wrap_set_source_any(apol_policy_t *p, int is_any) {
 		apol_avrule_query_set_source_any(p, self, is_any);
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_avrule_query_set_regex(p, self, regex);
 	};
 };
@@ -2168,7 +2283,7 @@ char *apol_syn_avrule_render(apol_policy_t * policy, qpol_syn_avrule_t * rule);
 /* apol terule query */
 typedef struct apol_terule_query {} apol_terule_query_t;
 %extend apol_terule_query_t {
-	apol_terule_query_t() {
+	apol_terule_query() {
 		apol_terule_query_t *atq;
 		BEGIN_EXCEPTION
 		atq = apol_terule_query_create();
@@ -2179,7 +2294,7 @@ typedef struct apol_terule_query {} apol_terule_query_t;
 	fail:
 		return atq;
 	};
-	~apol_terule_query_t() {
+	~apol_terule_query() {
 		apol_terule_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -2204,10 +2319,12 @@ typedef struct apol_terule_query {} apol_terule_query_t;
 	fail:
 		return v;
 	};
-	void set_rules(apol_policy_t *p, int rules) {
+	%rename(set_rules) wrap_set_rules;
+	void wrap_set_rules(apol_policy_t *p, int rules) {
 		apol_terule_query_set_rules(p, self, rules);
 	};
-	void set_source(apol_policy_t *p, char *name, int indirect) {
+	%rename(set_source) wrap_set_source;
+	void wrap_set_source(apol_policy_t *p, char *name, int indirect) {
 		BEGIN_EXCEPTION
 		if (apol_terule_query_set_source(p, self, name, indirect)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set source for terule query");
@@ -2216,7 +2333,8 @@ typedef struct apol_terule_query {} apol_terule_query_t;
 	fail:
 		return;
 	};
-	void set_source_component(apol_policy_t *p, int component) {
+	%rename(set_source_component) wrap_set_source_component;
+	void wrap_set_source_component(apol_policy_t *p, int component) {
 		BEGIN_EXCEPTION
 		if (apol_terule_query_set_source_component(p, self, component)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set source component for terule query");
@@ -2225,7 +2343,8 @@ typedef struct apol_terule_query {} apol_terule_query_t;
 	fail:
 		return;
 	};
-	void set_target(apol_policy_t *p, char *name, int indirect) {
+	%rename(set_target) wrap_set_target;
+	void wrap_set_target(apol_policy_t *p, char *name, int indirect) {
 		BEGIN_EXCEPTION
 		if (apol_terule_query_set_target(p, self, name, indirect)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set target for terule query");
@@ -2234,7 +2353,8 @@ typedef struct apol_terule_query {} apol_terule_query_t;
 	fail:
 		return;
 	};
-	void set_target_component(apol_policy_t *p, int component) {
+	%rename(set_target_component) wrap_set_target_component;
+	void wrap_set_target_component(apol_policy_t *p, int component) {
 		BEGIN_EXCEPTION
 		if (apol_terule_query_set_target_component(p, self, component)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set target component for terule query");
@@ -2243,7 +2363,8 @@ typedef struct apol_terule_query {} apol_terule_query_t;
 	fail:
 		return;
 	};
-	void append_class(apol_policy_t *p, char *name) {
+	%rename(append_class) wrap_append_class;
+	void wrap_append_class(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_terule_query_append_class(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append class to terule query");
@@ -2252,7 +2373,8 @@ typedef struct apol_terule_query {} apol_terule_query_t;
 	fail:
 		return;
 	};
-	void set_default(apol_policy_t *p, char *name) {
+	%rename(set_default) wrap_set_default;
+	void wrap_set_default(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_terule_query_set_default(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set default for terule query");
@@ -2261,7 +2383,8 @@ typedef struct apol_terule_query {} apol_terule_query_t;
 	fail:
 		return;
 	};
-	void set_bool(apol_policy_t *p, char *name) {
+	%rename(set_bool) wrap_set_bool;
+	void wrap_set_bool(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_terule_query_set_bool(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set boolean for terule query");
@@ -2270,13 +2393,16 @@ typedef struct apol_terule_query {} apol_terule_query_t;
 	fail:
 		return;
 	};
-	void set_enabled(apol_policy_t *p, int enabled) {
+	%rename(set_enabled) wrap_set_enabled;
+	void wrap_set_enabled(apol_policy_t *p, int enabled) {
 		apol_terule_query_set_enabled(p, self, enabled);
 	};
-	void set_source_any(apol_policy_t *p, int is_any) {
+	%rename(set_source_any) wrap_set_source_any;
+	void wrap_set_source_any(apol_policy_t *p, int is_any) {
 		apol_terule_query_set_source_any(p, self, is_any);
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_terule_query_set_regex(p, self, regex);
 	};
 };
@@ -2292,7 +2418,7 @@ apol_vector_t *apol_terule_list_to_syn_terules(apol_policy_t * p, apol_vector_t 
 /* apol cond rule query */
 typedef struct apol_cond_query {} apol_cond_query_t;
 %extend apol_cond_query_t {
-	apol_cond_query_t() {
+	apol_cond_query() {
 		apol_cond_query_t *acq;
 		BEGIN_EXCEPTION
 		acq = apol_cond_query_create();
@@ -2303,7 +2429,7 @@ typedef struct apol_cond_query {} apol_cond_query_t;
 	fail:
 		return acq;
 	};
-	~apol_cond_query_t() {
+	~apol_cond_query() {
 		apol_cond_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -2317,7 +2443,8 @@ typedef struct apol_cond_query {} apol_cond_query_t;
 	fail:
 		return v;
 	};
-	void set_bool(apol_policy_t *p, char *name) {
+	%rename(set_bool) wrap_set_bool;
+	void wrap_set_bool(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_cond_query_set_bool(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set boolean for condiional query");
@@ -2326,7 +2453,8 @@ typedef struct apol_cond_query {} apol_cond_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_cond_query_set_regex(p, self, regex);
 	};
 };
@@ -2336,7 +2464,7 @@ char *apol_cond_expr_render(apol_policy_t * p, qpol_cond_t * cond);
 /* apol role allow query */
 typedef struct apol_role_allow_query {} apol_role_allow_query_t;
 %extend apol_role_allow_query_t {
-	apol_role_allow_query_t() {
+	apol_role_allow_query() {
 		apol_role_allow_query_t *arq;
 		BEGIN_EXCEPTION
 		arq = apol_role_allow_query_create();
@@ -2347,7 +2475,7 @@ typedef struct apol_role_allow_query {} apol_role_allow_query_t;
 	fail:
 		return arq;
 	};
-	~apol_role_allow_query_t() {
+	~apol_role_allow_query() {
 		apol_role_allow_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -2361,7 +2489,8 @@ typedef struct apol_role_allow_query {} apol_role_allow_query_t;
 	fail:
 		return v;
 	};
-	void set_source(apol_policy_t *p, char *name) {
+	%rename(set_source) wrap_set_source;
+	void wrap_set_source(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_role_allow_query_set_source(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2370,7 +2499,8 @@ typedef struct apol_role_allow_query {} apol_role_allow_query_t;
 	fail:
 		return;
 	};
-	void set_target(apol_policy_t *p, char *name) {
+	%rename(set_target) wrap_set_target;
+	void wrap_set_target(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_role_allow_query_set_target(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2379,10 +2509,12 @@ typedef struct apol_role_allow_query {} apol_role_allow_query_t;
 	fail:
 		return;
 	};
-	void set_source_any(apol_policy_t *p, int is_any) {
+	%rename(set_source_any) wrap_set_source_any;
+	void wrap_set_source_any(apol_policy_t *p, int is_any) {
 		apol_role_allow_query_set_source_any(p, self, is_any);
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_role_allow_query_set_regex(p, self, regex);
 	};
 };
@@ -2392,7 +2524,7 @@ char *apol_role_allow_render(apol_policy_t * policy, qpol_role_allow_t * rule);
 /* apol role transition rule query */
 typedef struct apol_role_trans_query {} apol_role_trans_query_t;
 %extend apol_role_trans_query_t {
-	apol_role_trans_query_t() {
+	apol_role_trans_query() {
 		apol_role_trans_query_t *arq;
 		BEGIN_EXCEPTION
 		arq = apol_role_trans_query_create();
@@ -2403,7 +2535,7 @@ typedef struct apol_role_trans_query {} apol_role_trans_query_t;
 	fail:
 		return arq;
 	};
-	~apol_role_trans_query_t() {
+	~apol_role_trans_query() {
 		apol_role_trans_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -2417,7 +2549,8 @@ typedef struct apol_role_trans_query {} apol_role_trans_query_t;
 	fail:
 		return v;
 	};
-	void set_source(apol_policy_t *p, char *name) {
+	%rename(set_source) wrap_set_source;
+	void wrap_set_source(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_role_trans_query_set_source(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2426,7 +2559,8 @@ typedef struct apol_role_trans_query {} apol_role_trans_query_t;
 	fail:
 		return;
 	};
-	void set_target(apol_policy_t *p, char *name, int indirect) {
+	%rename(set_target) wrap_set_target;
+	void wrap_set_target(apol_policy_t *p, char *name, int indirect) {
 		BEGIN_EXCEPTION
 		if (apol_role_trans_query_set_target(p, self, name, indirect)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2435,7 +2569,8 @@ typedef struct apol_role_trans_query {} apol_role_trans_query_t;
 	fail:
 		return;
 	};
-	void set_default(apol_policy_t *p, char *name) {
+	%rename(set_default) wrap_set_default;
+	void wrap_set_default(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_role_trans_query_set_default(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2444,10 +2579,12 @@ typedef struct apol_role_trans_query {} apol_role_trans_query_t;
 	fail:
 		return;
 	};
-	void set_source_any(apol_policy_t *p, int is_any) {
+	%rename(set_source_any) wrap_set_source_any;
+	void wrap_set_source_any(apol_policy_t *p, int is_any) {
 		apol_role_trans_query_set_source_any(p, self, is_any);
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_role_trans_query_set_regex(p, self, regex);
 	};
 };
@@ -2457,7 +2594,7 @@ char *apol_role_trans_render(apol_policy_t * policy, qpol_role_trans_t * rule);
 /* apol range transition rule query */
 typedef struct apol_range_trans_query {} apol_range_trans_query_t;
 %extend apol_range_trans_query_t {
-	apol_range_trans_query_t() {
+	apol_range_trans_query() {
 		apol_range_trans_query_t *arq;
 		BEGIN_EXCEPTION
 		arq = apol_range_trans_query_create();
@@ -2468,7 +2605,7 @@ typedef struct apol_range_trans_query {} apol_range_trans_query_t;
 	fail:
 		return arq;
 	};
-	~apol_range_trans_query_t() {
+	~apol_range_trans_query() {
 		apol_range_trans_query_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -2482,7 +2619,8 @@ typedef struct apol_range_trans_query {} apol_range_trans_query_t;
 	fail:
 		return v;
 	};
-	void set_source(apol_policy_t *p, char *name, int indirect) {
+	%rename(set_source) wrap_set_source;
+	void wrap_set_source(apol_policy_t *p, char *name, int indirect) {
 		BEGIN_EXCEPTION
 		if (apol_range_trans_query_set_source(p, self, name, indirect)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2491,7 +2629,8 @@ typedef struct apol_range_trans_query {} apol_range_trans_query_t;
 	fail:
 		return;
 	};
-	void set_target(apol_policy_t *p, char *name, int indirect) {
+	%rename(set_target) wrap_set_target;
+	void wrap_set_target(apol_policy_t *p, char *name, int indirect) {
 		BEGIN_EXCEPTION
 		if (apol_range_trans_query_set_target(p, self, name, indirect)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2500,7 +2639,8 @@ typedef struct apol_range_trans_query {} apol_range_trans_query_t;
 	fail:
 		return;
 	};
-	void append_class(apol_policy_t *p, char *name) {
+	%rename(append_class) wrap_append_class;
+	void wrap_append_class(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_range_trans_query_append_class(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append class to range transition query");
@@ -2509,7 +2649,8 @@ typedef struct apol_range_trans_query {} apol_range_trans_query_t;
 	fail:
 		return;
 	};
-	void set_range(apol_policy_t *p, apol_mls_range_t *rng, int range_match) {
+	%rename(set_range) wrap_set_range;
+	void wrap_set_range(apol_policy_t *p, apol_mls_range_t *rng, int range_match) {
 		BEGIN_EXCEPTION
 		if (apol_range_trans_query_set_range(p, self, rng, range_match)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2518,10 +2659,12 @@ typedef struct apol_range_trans_query {} apol_range_trans_query_t;
 	fail:
 		return;
 	};
-	void set_source_any(apol_policy_t *p, int is_any) {
+	%rename(set_source_any) wrap_set_source_any;
+	void wrap_set_source_any(apol_policy_t *p, int is_any) {
 		apol_range_trans_query_set_source_any(p, self, is_any);
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_range_trans_query_set_regex(p, self, regex);
 	};
 };
@@ -2556,7 +2699,8 @@ typedef struct apol_filename_trans_query {} apol_filename_trans_query_t;
 	fail:
 		return v;
 	};
-	void set_source(apol_policy_t *p, char *name, int indirect) {
+	%rename(set_source) wrap_set_source;
+	void wrap_set_source(apol_policy_t *p, char *name, int indirect) {
 		BEGIN_EXCEPTION
 		if (apol_filename_trans_query_set_source(p, self, name, indirect)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2565,7 +2709,8 @@ typedef struct apol_filename_trans_query {} apol_filename_trans_query_t;
 	fail:
 		return;
 	};
-	void set_target(apol_policy_t *p, char *name, int indirect) {
+	%rename(set_target) wrap_set_target;
+	void wrap_set_target(apol_policy_t *p, char *name, int indirect) {
 		BEGIN_EXCEPTION
 		if (apol_filename_trans_query_set_target(p, self, name, indirect)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2574,7 +2719,8 @@ typedef struct apol_filename_trans_query {} apol_filename_trans_query_t;
 	fail:
 		return;
 	};
-	void append_class(apol_policy_t *p, char *name) {
+	%rename(append_class) wrap_append_class;
+	void wrap_append_class(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_filename_trans_query_append_class(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append class to filename transition query");
@@ -2584,7 +2730,8 @@ typedef struct apol_filename_trans_query {} apol_filename_trans_query_t;
 		return;
 	};
 
-	void set_default(apol_policy_t *p, char *name) {
+	%rename(set_default) wrap_set_default;
+	void wrap_set_default(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_filename_trans_query_set_default(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set default for filename transition query");
@@ -2604,10 +2751,12 @@ typedef struct apol_filename_trans_query {} apol_filename_trans_query_t;
 		return;
 	};
 
-	void set_source_any(apol_policy_t *p, int is_any) {
+	%rename(set_source_any) wrap_set_source_any;
+	void wrap_set_source_any(apol_policy_t *p, int is_any) {
 		apol_filename_trans_query_set_source_any(p, self, is_any);
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_filename_trans_query_set_regex(p, self, regex);
 	};
 };
@@ -2643,7 +2792,8 @@ typedef struct apol_permissive_query {} apol_permissive_query_t;
 		return v;
 	};
 
-	void set_name(apol_policy_t *p, char *name) {
+	%rename(set_name) wrap_set_name;
+	void wrap_set_name(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_permissive_query_set_name(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2653,7 +2803,8 @@ typedef struct apol_permissive_query {} apol_permissive_query_t;
 		return;
 	};
 
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_permissive_query_set_regex(p, self, regex);
 	};
 };
@@ -2687,7 +2838,8 @@ typedef struct apol_polcap_query {} apol_polcap_query_t;
 		return v;
 	};
 
-	void set_name(apol_policy_t *p, char *name) {
+	%rename(set_name) wrap_set_name;
+	void wrap_set_name(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_polcap_query_set_name(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2697,7 +2849,8 @@ typedef struct apol_polcap_query {} apol_polcap_query_t;
 		return;
 	};
 
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_polcap_query_set_regex(p, self, regex);
 	};
 };
@@ -2730,7 +2883,8 @@ typedef struct apol_typebounds_query {} apol_typebounds_query_t;
 	fail:
 		return v;
 	};
-	void set_name(apol_policy_t *p, char *name) {
+	%rename(set_name) wrap_set_name;
+	void wrap_set_name(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_typebounds_query_set_name(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2739,7 +2893,8 @@ typedef struct apol_typebounds_query {} apol_typebounds_query_t;
 	fail:
 		return;
 	};
-	void set_regex(apol_policy_t *p, int regex) {
+	%rename(set_regex) wrap_set_regex;
+	void wrap_set_regex(apol_policy_t *p, int regex) {
 		apol_typebounds_query_set_regex(p, self, regex);
 	};
 };
@@ -2842,7 +2997,7 @@ typedef struct apol_default_object_query {} apol_default_object_query_t;
 #define APOL_DOMAIN_TRANS_SEARCH_BOTH		(APOL_DOMAIN_TRANS_SEARCH_VALID|APOL_DOMAIN_TRANS_SEARCH_INVALID)
 typedef struct apol_domain_trans_analysis {} apol_domain_trans_analysis_t;
 %extend apol_domain_trans_analysis_t {
-	apol_domain_trans_analysis_t() {
+	apol_domain_trans_analysis() {
 		apol_domain_trans_analysis_t *dta;
 		BEGIN_EXCEPTION
 		dta = apol_domain_trans_analysis_create();
@@ -2853,10 +3008,11 @@ typedef struct apol_domain_trans_analysis {} apol_domain_trans_analysis_t;
 	fail:
 		return dta;
 	};
-	~apol_domain_trans_analysis_t() {
+	~apol_domain_trans_analysis() {
 		apol_domain_trans_analysis_destroy(&self);
 	};
-	void set_direction(apol_policy_t *p, int direction) {
+	%rename(set_direction) wrap_set_direction;
+	void wrap_set_direction(apol_policy_t *p, int direction) {
 		BEGIN_EXCEPTION
 		if (apol_domain_trans_analysis_set_direction(p, self, (unsigned char)direction)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set direction for domain transition analysis");
@@ -2865,7 +3021,8 @@ typedef struct apol_domain_trans_analysis {} apol_domain_trans_analysis_t;
 	fail:
 		return;
 	};
-	void set_valid(apol_policy_t *p, int valid) {
+	%rename(set_valid) wrap_set_valid;
+	void wrap_set_valid(apol_policy_t *p, int valid) {
 		BEGIN_EXCEPTION
 		if (apol_domain_trans_analysis_set_valid(p, self, (unsigned char)valid)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set valid flag for domain transition analysis");
@@ -2874,7 +3031,8 @@ typedef struct apol_domain_trans_analysis {} apol_domain_trans_analysis_t;
 	fail:
 		return;
 	};
-	void set_start_type(apol_policy_t *p, char *name) {
+	%rename(set_start_type) wrap_set_start_type;
+	void wrap_set_start_type(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_domain_trans_analysis_set_start_type(p, self, name)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2883,7 +3041,8 @@ typedef struct apol_domain_trans_analysis {} apol_domain_trans_analysis_t;
 	fail:
 		return;
 	};
-	void set_result_regex(apol_policy_t *p, char *regex) {
+	%rename(set_result_regex) wrap_set_result_regex;
+	void wrap_set_result_regex(apol_policy_t *p, char *regex) {
 		BEGIN_EXCEPTION
 		if (apol_domain_trans_analysis_set_result_regex(p, self, regex)) {
 			SWIG_exception(SWIG_MemoryError, "Out of memory");
@@ -2892,7 +3051,8 @@ typedef struct apol_domain_trans_analysis {} apol_domain_trans_analysis_t;
 	fail:
 		return;
 	};
-	void append_access_type(apol_policy_t *p, char *name) {
+	%rename(append_access_type) wrap_append_access_type;
+	void wrap_append_access_type(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_domain_trans_analysis_append_access_type(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append access type for domain transition analysis");
@@ -2901,7 +3061,8 @@ typedef struct apol_domain_trans_analysis {} apol_domain_trans_analysis_t;
 	fail:
 		return;
 	};
-	void append_class(apol_policy_t *p, char *class_name) {
+	%rename(append_class) wrap_append_class;
+	void wrap_append_class(apol_policy_t *p, char *class_name) {
 		BEGIN_EXCEPTION
 		if (apol_domain_trans_analysis_append_class(p, self, class_name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append access class for domain transition analysis");
@@ -2910,7 +3071,8 @@ typedef struct apol_domain_trans_analysis {} apol_domain_trans_analysis_t;
 	fail:
 		return;
 	};
-	void append_perm(apol_policy_t *p, char *perm_name) {
+	%rename(append_perm) wrap_append_perm;
+	void wrap_append_perm(apol_policy_t *p, char *perm_name) {
 		BEGIN_EXCEPTION
 		if (apol_domain_trans_analysis_append_perm(p, self, perm_name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append access permission for domain transition analysis");
@@ -2933,7 +3095,7 @@ typedef struct apol_domain_trans_analysis {} apol_domain_trans_analysis_t;
 };
 typedef struct apol_domain_trans_result {} apol_domain_trans_result_t;
 %extend apol_domain_trans_result_t {
-	apol_domain_trans_result_t(apol_domain_trans_result_t *in) {
+	apol_domain_trans_result(apol_domain_trans_result_t *in) {
 		apol_domain_trans_result_t *dtr;
 		BEGIN_EXCEPTION
 		dtr = apol_domain_trans_result_create_from_domain_trans_result(in);
@@ -2944,37 +3106,46 @@ typedef struct apol_domain_trans_result {} apol_domain_trans_result_t;
 	fail:
 		return dtr;
 	};
-	~apol_domain_trans_result_t() {
+	~apol_domain_trans_result() {
 		apol_domain_trans_result_destroy(&self);
 	};
-	const qpol_type_t *get_start_type() {
+	%rename(get_start_type) wrap_get_start_type;
+	const qpol_type_t *wrap_get_start_type() {
 		return apol_domain_trans_result_get_start_type(self);
 	};
-	const qpol_type_t *get_entrypoint_type() {
+	%rename(get_entrypoint_type) wrap_get_entrypoint_type;
+	const qpol_type_t *wrap_get_entrypoint_type() {
 		return apol_domain_trans_result_get_entrypoint_type(self);
 	};
-	const qpol_type_t *get_end_type() {
+	%rename(get_end_type) wrap_get_end_type;
+	const qpol_type_t *wrap_get_end_type() {
 		return apol_domain_trans_result_get_end_type(self);
 	};
 	int get_is_valid() {
 		return apol_domain_trans_result_is_trans_valid(self);
 	};
-	const apol_vector_t *get_proc_trans_rules() {
+	%rename(get_proc_trans_rules) wrap_get_proc_trans_rules;
+	const apol_vector_t *wrap_get_proc_trans_rules() {
 		return apol_domain_trans_result_get_proc_trans_rules(self);
 	};
-	const apol_vector_t *get_entrypoint_rules() {
+	%rename(get_entrypoint_rules) wrap_get_entrypoint_rules;
+	const apol_vector_t *wrap_get_entrypoint_rules() {
 		return apol_domain_trans_result_get_entrypoint_rules(self);
 	};
-	const apol_vector_t *get_exec_rules() {
+	%rename(get_exec_rules) wrap_get_exec_rules;
+	const apol_vector_t *wrap_get_exec_rules() {
 		return apol_domain_trans_result_get_exec_rules(self);
 	};
-	const apol_vector_t *get_setexec_rules() {
+	%rename(get_setexec_rules) wrap_get_setexec_rules;
+	const apol_vector_t *wrap_get_setexec_rules() {
 		return apol_domain_trans_result_get_setexec_rules(self);
 	};
-	const apol_vector_t *get_type_trans_rules() {
+	%rename(get_type_trans_rules) wrap_get_type_trans_rules;
+	const apol_vector_t *wrap_get_type_trans_rules() {
 		return apol_domain_trans_result_get_type_trans_rules(self);
 	};
-	const apol_vector_t *get_access_rules() {
+	%rename(get_access_rules) wrap_get_access_rules;
+	const apol_vector_t *wrap_get_access_rules() {
 		return apol_domain_trans_result_get_access_rules(self);
 	};
 };
@@ -3016,14 +3187,14 @@ int apol_domain_trans_table_verify_trans(apol_policy_t * policy, qpol_type_t * s
 %}
 typedef struct apol_infoflow {} apol_infoflow_t;
 %extend apol_infoflow_t {
-	apol_infoflow_t() {
+	apol_infoflow() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create apol_infoflow_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~apol_infoflow_t() {
+	~apol_infoflow() {
 		apol_infoflow_destroy(&self);
 	};
 	%newobject extract_graph();
@@ -3041,7 +3212,7 @@ typedef struct apol_infoflow {} apol_infoflow_t;
 };
 typedef struct apol_infoflow_analysis {} apol_infoflow_analysis_t;
 %extend apol_infoflow_analysis_t {
-	apol_infoflow_analysis_t() {
+	apol_infoflow_analysis() {
 		apol_infoflow_analysis_t *aia;
 		BEGIN_EXCEPTION
 		aia = apol_infoflow_analysis_create();
@@ -3052,7 +3223,7 @@ typedef struct apol_infoflow_analysis {} apol_infoflow_analysis_t;
 	fail:
 		return aia;
 	};
-	~apol_infoflow_analysis_t() {
+	~apol_infoflow_analysis() {
 		apol_infoflow_analysis_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -3074,7 +3245,8 @@ typedef struct apol_infoflow_analysis {} apol_infoflow_analysis_t;
 		apol_infoflow_destroy(&ai);
 		return NULL;
 	};
-	void set_mode(apol_policy_t *p, int mode) {
+	%rename(set_mode) wrap_set_mode;
+	void wrap_set_mode(apol_policy_t *p, int mode) {
 		BEGIN_EXCEPTION
 		if (apol_infoflow_analysis_set_mode(p, self, (unsigned int)mode)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set mode for information flow analysis");
@@ -3083,7 +3255,8 @@ typedef struct apol_infoflow_analysis {} apol_infoflow_analysis_t;
 	fail:
 		return;
 	};
-	void set_dir(apol_policy_t *p, int direction) {
+	%rename(set_dir) wrap_set_dir;
+	void wrap_set_dir(apol_policy_t *p, int direction) {
 		BEGIN_EXCEPTION
 		if (apol_infoflow_analysis_set_dir(p, self, (unsigned int)direction)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set direction for information flow analysis");
@@ -3092,7 +3265,8 @@ typedef struct apol_infoflow_analysis {} apol_infoflow_analysis_t;
 	fail:
 		return;
 	};
-	void set_type(apol_policy_t *p, char *name) {
+	%rename(set_type) wrap_set_type;
+	void wrap_set_type(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_infoflow_analysis_set_type(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set type for information flow analysis");
@@ -3101,7 +3275,8 @@ typedef struct apol_infoflow_analysis {} apol_infoflow_analysis_t;
 	fail:
 		return;
 	};
-	void append_intermediate(apol_policy_t *p, char *name) {
+	%rename(append_intermediate) wrap_append_intermediate;
+	void wrap_append_intermediate(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_infoflow_analysis_append_intermediate(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append intermediate type for information flow analysis");
@@ -3110,7 +3285,8 @@ typedef struct apol_infoflow_analysis {} apol_infoflow_analysis_t;
 	fail:
 		return;
 	};
-	void append_class_perm(apol_policy_t *p, char *class_name, char *perm_name) {
+	%rename(append_class_perm) wrap_append_class_perm;
+	void wrap_append_class_perm(apol_policy_t *p, char *class_name, char *perm_name) {
 		BEGIN_EXCEPTION
 		if (apol_infoflow_analysis_append_class_perm(p, self, class_name, perm_name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append class and permission for information flow analysis");
@@ -3119,10 +3295,12 @@ typedef struct apol_infoflow_analysis {} apol_infoflow_analysis_t;
 	fail:
 		return;
 	};
-	void set_min_weight(apol_policy_t *p, int weight) {
+	%rename(set_min_weight) wrap_set_min_weight;
+	void wrap_set_min_weight(apol_policy_t *p, int weight) {
 		apol_infoflow_analysis_set_min_weight(p, self, weight);
 	};
-	void set_result_regex(apol_policy_t *p, char *regex) {
+	%rename(set_result_regex) wrap_set_result_regex;
+	void wrap_set_result_regex(apol_policy_t *p, char *regex) {
 		BEGIN_EXCEPTION
 		if (apol_infoflow_analysis_set_result_regex(p, self, regex)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set result regular expression for information flow analysis");
@@ -3134,14 +3312,14 @@ typedef struct apol_infoflow_analysis {} apol_infoflow_analysis_t;
 };
 typedef struct apol_infoflow_graph {} apol_infoflow_graph_t;
 %extend apol_infoflow_graph_t {
-	apol_infoflow_graph_t() {
+	apol_infoflow_graph() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create apol_infoflow_graph_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~apol_infoflow_graph_t() {
+	~apol_infoflow_graph() {
 		apol_infoflow_graph_destroy(&self);
 	};
 	%newobject do_more(apol_policy_t*, char*);
@@ -3178,30 +3356,35 @@ typedef struct apol_infoflow_graph {} apol_infoflow_graph_t;
 };
 typedef struct apol_infoflow_result {} apol_infoflow_result_t;
 %extend apol_infoflow_result_t {
-	apol_infoflow_result_t() {
+	apol_infoflow_result() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create apol_infoflow_result_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~apol_infoflow_result_t() {
+	~apol_infoflow_result() {
 		/* no op - vector will destroy */
 		return;
 	};
-	int get_dir() {
+	%rename(get_dir) wrap_get_dir;
+	int wrap_get_dir() {
 		return (int)apol_infoflow_result_get_dir(self);
 	};
-	const qpol_type_t *get_start_type() {
+	%rename(get_start_type) wrap_get_start_type;
+	const qpol_type_t *wrap_get_start_type() {
 		return apol_infoflow_result_get_start_type(self);
 	};
-	const qpol_type_t *get_end_type() {
+	%rename(get_end_type) wrap_get_end_type;
+	const qpol_type_t *wrap_get_end_type() {
 		return apol_infoflow_result_get_end_type(self);
 	};
-	int get_length() {
+	%rename(get_length) wrap_get_length;
+	int wrap_get_length() {
 		return (int) apol_infoflow_result_get_length(self);
 	}
-	const apol_vector_t *get_steps() {
+	%rename(get_steps) wrap_get_steps;
+	const apol_vector_t *wrap_get_steps() {
 		return apol_infoflow_result_get_steps(self);
 	};
 };
@@ -3212,27 +3395,31 @@ typedef struct apol_infoflow_result {} apol_infoflow_result_t;
 %}
 typedef struct apol_infoflow_step {} apol_infoflow_step_t;
 %extend apol_infoflow_step_t {
-	apol_infoflow_step_t() {
+	apol_infoflow_step() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create apol_infoflow_step_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~apol_infoflow_step_t() {
+	~apol_infoflow_step() {
 		/* no op */
 		return;
 	};
-	const qpol_type_t *get_start_type() {
+	%rename(get_start_type) wrap_get_start_type;
+	const qpol_type_t *wrap_get_start_type() {
 		return apol_infoflow_step_get_start_type(self);
 	};
-	const qpol_type_t *get_end_type() {
+	%rename(get_end_type) wrap_get_end_type;
+	const qpol_type_t *wrap_get_end_type() {
 		return apol_infoflow_step_get_end_type(self);
 	};
-	int get_weight() {
+	%rename(get_weight) wrap_get_weight;
+	int wrap_get_weight() {
 		return apol_infoflow_step_get_weight(self);
 	};
-	const apol_vector_t *get_rules() {
+	%rename(get_rules) wrap_get_rules;
+	const apol_vector_t *wrap_get_rules() {
 		return apol_infoflow_step_get_rules(self);
 	};
 };
@@ -3249,7 +3436,7 @@ typedef struct apol_infoflow_step {} apol_infoflow_step_t;
 #define APOL_RELABEL_DIR_SUBJECT 0x04
 typedef struct apol_relabel_analysis {} apol_relabel_analysis_t;
 %extend apol_relabel_analysis_t {
-	apol_relabel_analysis_t() {
+	apol_relabel_analysis() {
 		apol_relabel_analysis_t *ara;
 		BEGIN_EXCEPTION
 		ara = apol_relabel_analysis_create();
@@ -3260,7 +3447,7 @@ typedef struct apol_relabel_analysis {} apol_relabel_analysis_t;
 	fail:
 		return ara;
 	};
-	~apol_relabel_analysis_t() {
+	~apol_relabel_analysis() {
 		apol_relabel_analysis_destroy(&self);
 	};
 	%newobject run(apol_policy_t*);
@@ -3274,7 +3461,8 @@ typedef struct apol_relabel_analysis {} apol_relabel_analysis_t;
 	fail:
 		return v;
 	};
-	void set_dir(apol_policy_t *p, int direction) {
+	%rename(set_dir) wrap_set_dir;
+	void wrap_set_dir(apol_policy_t *p, int direction) {
 		BEGIN_EXCEPTION
 		if (apol_relabel_analysis_set_dir(p, self, (unsigned int)direction)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set direction for relabel analysis");
@@ -3283,7 +3471,8 @@ typedef struct apol_relabel_analysis {} apol_relabel_analysis_t;
 	fail:
 		return;
 	};
-	void set_type(apol_policy_t *p, char *name) {
+	%rename(set_type) wrap_set_type;
+	void wrap_set_type(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_relabel_analysis_set_type(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set type for relabel analysis");
@@ -3292,7 +3481,8 @@ typedef struct apol_relabel_analysis {} apol_relabel_analysis_t;
 	fail:
 		return;
 	};
-	void append_class(apol_policy_t *p, char *name) {
+	%rename(append_class) wrap_append_class;
+	void wrap_append_class(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_relabel_analysis_append_class(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append class to relabel analysis");
@@ -3301,7 +3491,8 @@ typedef struct apol_relabel_analysis {} apol_relabel_analysis_t;
 	fail:
 		return;
 	};
-	void append_subject(apol_policy_t *p, char *name) {
+	%rename(append_subject) wrap_append_subject;
+	void wrap_append_subject(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_relabel_analysis_append_subject(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append subject to relabel analysis");
@@ -3310,7 +3501,8 @@ typedef struct apol_relabel_analysis {} apol_relabel_analysis_t;
 	fail:
 		return;
 	};
-	void set_result_regex(apol_policy_t *p, char *regex) {
+	%rename(set_result_regex) wrap_set_result_regex;
+	void wrap_set_result_regex(apol_policy_t *p, char *regex) {
 		BEGIN_EXCEPTION
 		if (apol_relabel_analysis_set_result_regex(p, self, regex)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set result regular expression for relabel analysis");
@@ -3322,27 +3514,31 @@ typedef struct apol_relabel_analysis {} apol_relabel_analysis_t;
 };
 typedef struct apol_relabel_result {} apol_relabel_result_t;
 %extend apol_relabel_result_t {
-	apol_relabel_result_t() {
+	apol_relabel_result() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create apol_relabel_result_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~apol_relabel_result_t() {
+	~apol_relabel_result() {
 		/* no op - vector will destroy */
 		return;
 	};
-	const apol_vector_t *get_to() {
+	%rename(get_to) wrap_get_to;
+	const apol_vector_t *wrap_get_to() {
 		return apol_relabel_result_get_to(self);
 	};
-	const apol_vector_t *get_from() {
+	%rename(get_from) wrap_get_from;
+	const apol_vector_t *wrap_get_from() {
 		return apol_relabel_result_get_from(self);
 	};
-	const apol_vector_t *get_both() {
+	%rename(get_both) wrap_get_both;
+	const apol_vector_t *wrap_get_both() {
 		return apol_relabel_result_get_both(self);
 	};
-	const qpol_type_t *get_result_type() {
+	%rename(get_result_type) wrap_get_result_type;
+	const qpol_type_t *wrap_get_result_type() {
 		return apol_relabel_result_get_result_type(self);
 	};
 };
@@ -3353,24 +3549,27 @@ typedef struct apol_relabel_result {} apol_relabel_result_t;
 %}
 typedef struct apol_relabel_result_pair {} apol_relabel_result_pair_t;
 %extend apol_relabel_result_pair_t {
-	apol_relabel_result_pair_t() {
+	apol_relabel_result_pair() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create apol_relabel_result_pair_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~apol_relabel_result_pair_t() {
+	~apol_relabel_result_pair() {
 		/* no op - owned and free()'d by apol_relabel_result_t */
 		return;
 	};
-	const qpol_avrule_t *get_ruleA() {
+	%rename(get_ruleA) wrap_get_ruleA;
+	const qpol_avrule_t *wrap_get_ruleA() {
 		return apol_relabel_result_pair_get_ruleA(self);
 	};
-	const qpol_avrule_t *get_ruleB() {
+	%rename(get_ruleB) wrap_get_ruleB;
+	const qpol_avrule_t *wrap_get_ruleB() {
 		return apol_relabel_result_pair_get_ruleB(self);
 	};
-	const qpol_type_t *get_intermediate_type() {
+	%rename(get_intermediate_type) wrap_get_intermediate_type;
+	const qpol_type_t *wrap_get_intermediate_type() {
 		return apol_relabel_result_pair_get_intermediate_type(self);
 	};
 };
@@ -3395,7 +3594,7 @@ typedef struct apol_relabel_result_pair {} apol_relabel_result_pair_t;
 #define APOL_TYPES_RELATION_TRANS_FLOW_BA 0x8000
 typedef struct apol_types_relation_analysis {} apol_types_relation_analysis_t;
 %extend apol_types_relation_analysis_t {
-	apol_types_relation_analysis_t() {
+	apol_types_relation_analysis() {
 		apol_types_relation_analysis_t *atr;
 		BEGIN_EXCEPTION
 		atr = apol_types_relation_analysis_create();
@@ -3406,7 +3605,7 @@ typedef struct apol_types_relation_analysis {} apol_types_relation_analysis_t;
 	fail:
 		return atr;
 	};
-	~apol_types_relation_analysis_t() {
+	~apol_types_relation_analysis() {
 		apol_types_relation_analysis_destroy(&self);
 	}
 	%newobject run(apol_policy_t*);
@@ -3420,7 +3619,8 @@ typedef struct apol_types_relation_analysis {} apol_types_relation_analysis_t;
 	fail:
 		return res;
 	};
-	void set_first_type(apol_policy_t *p, char *name) {
+	%rename(set_first_type) wrap_set_first_type;
+	void wrap_set_first_type(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_types_relation_analysis_set_first_type(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set first type for types relation analysis");
@@ -3429,7 +3629,8 @@ typedef struct apol_types_relation_analysis {} apol_types_relation_analysis_t;
 	fail:
 		return;
 	};
-	void set_other_type(apol_policy_t *p, char *name) {
+	%rename(set_other_type) wrap_set_other_type;
+	void wrap_set_other_type(apol_policy_t *p, char *name) {
 		BEGIN_EXCEPTION
 		if (apol_types_relation_analysis_set_other_type(p, self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set other type for types relation analysis");
@@ -3438,7 +3639,8 @@ typedef struct apol_types_relation_analysis {} apol_types_relation_analysis_t;
 	fail:
 		return;
 	};
-	void set_analyses(apol_policy_t *p, int analyses) {
+	%rename(set_analyses) wrap_set_analyses;
+	void wrap_set_analyses(apol_policy_t *p, int analyses) {
 		BEGIN_EXCEPTION
 		if (apol_types_relation_analysis_set_analyses(p, self, (unsigned int)analyses)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set analyses to run for types relation analysis");
@@ -3450,76 +3652,92 @@ typedef struct apol_types_relation_analysis {} apol_types_relation_analysis_t;
 };
 typedef struct apol_types_relation_result {} apol_types_relation_result_t;
 %extend apol_types_relation_result_t {
-	apol_types_relation_result_t() {
+	apol_types_relation_result() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create apol_types_relation_result_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~apol_types_relation_result_t() {
+	~apol_types_relation_result() {
 		apol_types_relation_result_destroy(&self);
 	};
-	const apol_vector_t *get_attributes() {
+	%rename(get_attributes) wrap_get_attributes;
+	const apol_vector_t *wrap_get_attributes() {
 		return apol_types_relation_result_get_attributes(self);
 	};
-	const apol_vector_t *get_roles() {
+	%rename(get_roles) wrap_get_roles;
+	const apol_vector_t *wrap_get_roles() {
 		return apol_types_relation_result_get_roles(self);
 	};
-	const apol_vector_t *get_users() {
+	%rename(get_users) wrap_get_users;
+	const apol_vector_t *wrap_get_users() {
 		return apol_types_relation_result_get_users(self);
 	};
-	const apol_vector_t *get_similar_first() {
+	%rename(get_similar_first) wrap_get_similar_first;
+	const apol_vector_t *wrap_get_similar_first() {
 		return apol_types_relation_result_get_similar_first(self);
 	};
-	const apol_vector_t *get_similar_other() {
+	%rename(get_similar_other) wrap_get_similar_other;
+	const apol_vector_t *wrap_get_similar_other() {
 		return apol_types_relation_result_get_similar_other(self);
 	};
-	const apol_vector_t *get_dissimilar_first() {
+	%rename(get_dissimilar_first) wrap_get_dissimilar_first;
+	const apol_vector_t *wrap_get_dissimilar_first() {
 		return apol_types_relation_result_get_dissimilar_first(self);
 	};
-	const apol_vector_t *get_dissimilar_other() {
+	%rename(get_dissimilar_other) wrap_get_dissimilar_other;
+	const apol_vector_t *wrap_get_dissimilar_other() {
 		return apol_types_relation_result_get_dissimilar_other(self);
 	};
-	const apol_vector_t *get_allowrules() {
+	%rename(get_allowrules) wrap_get_allowrules;
+	const apol_vector_t *wrap_get_allowrules() {
 		return apol_types_relation_result_get_allowrules(self);
 	};
-	const apol_vector_t *get_typerules() {
+	%rename(get_typerules) wrap_get_typerules;
+	const apol_vector_t *wrap_get_typerules() {
 		return apol_types_relation_result_get_typerules(self);
 	};
-	const apol_vector_t *get_directflows() {
+	%rename(get_directflows) wrap_get_directflows;
+	const apol_vector_t *wrap_get_directflows() {
 		return apol_types_relation_result_get_directflows(self);
 	};
-	const apol_vector_t *get_transflowsAB() {
+	%rename(get_transflowsAB) wrap_get_transflowsAB;
+	const apol_vector_t *wrap_get_transflowsAB() {
 		return apol_types_relation_result_get_transflowsAB(self);
 	};
-	const apol_vector_t *get_transflowsBA() {
+	%rename(get_transflowsBA) wrap_get_transflowsBA;
+	const apol_vector_t *wrap_get_transflowsBA() {
 		return apol_types_relation_result_get_transflowsBA(self);
 	};
-	const apol_vector_t*get_domainsAB() {
+	%rename(get_domainsAB) wrap_get_domainsAB;
+	const apol_vector_t*wrap_get_domainsAB() {
 		return apol_types_relation_result_get_domainsAB(self);
 	};
-	const apol_vector_t*get_domainsBA() {
+	%rename(get_domainsBA) wrap_get_domainsBA;
+	const apol_vector_t*wrap_get_domainsBA() {
 		return apol_types_relation_result_get_domainsBA(self);
 	};
 };
 typedef struct apol_types_relation_access {} apol_types_relation_access_t;
 %extend apol_types_relation_access_t {
-	apol_types_relation_access_t() {
+	apol_types_relation_access() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create apol_types_relation_access_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~apol_types_relation_access_t() {
+	~apol_types_relation_access() {
 		/* no op - vector will destroy */
 		return;
 	};
-	const qpol_type_t *get_type() {
+	%rename(get_type) wrap_get_type;
+	const qpol_type_t *wrap_get_type() {
 		return apol_types_relation_access_get_type(self);
 	};
-	const apol_vector_t *get_rules() {
+	%rename(get_rules) wrap_get_rules;
+	const apol_vector_t *wrap_get_rules() {
 		return apol_types_relation_access_get_rules(self);
 	};
 };

--- a/libpoldiff/swig/poldiff.i
+++ b/libpoldiff/swig/poldiff.i
@@ -273,7 +273,7 @@ typedef enum poldiff_form
 %}
 typedef struct poldiff_stats {} poldiff_stats_t;
 %extend poldiff_stats_t {
-	poldiff_stats_t() {
+	poldiff_stats() {
 		poldiff_stats_t *s;
 		BEGIN_EXCEPTION
 		s = poldiff_stats_create();
@@ -284,7 +284,7 @@ typedef struct poldiff_stats {} poldiff_stats_t;
 	fail:
 		return s;
 	};
-	~poldiff_stats_t() {
+	~poldiff_stats() {
 		poldiff_stats_destroy(&self);
 	};
 	size_t get_stat(poldiff_form_e form) {
@@ -348,7 +348,7 @@ unsigned long to_ulong(void *x);
 #endif
 typedef struct poldiff {} poldiff_t;
 %extend poldiff_t {
-	poldiff_t(apol_policy_t *op, apol_policy_t *mp) {
+	poldiff(apol_policy_t *op, apol_policy_t *mp) {
 		poldiff_t *p;
 		BEGIN_EXCEPTION
 		p = poldiff_create(op, mp, poldiff_swig_message_callback, poldiff_swig_message_callback_arg);
@@ -360,10 +360,11 @@ typedef struct poldiff {} poldiff_t;
 	fail:
 		return NULL;
 	};
-	~poldiff_t() {
+	~poldiff() {
 		poldiff_destroy(&self);
 	};
-	void run(uint32_t flags) {
+	%rename(run) wrap_run;
+	void wrap_run(uint32_t flags) {
 		BEGIN_EXCEPTION
 		if (poldiff_run(self, flags)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not run diff");
@@ -372,11 +373,13 @@ typedef struct poldiff {} poldiff_t;
 	fail:
 		return;
 	};
-	int is_run(uint32_t flags) {
+	%rename(is_run) wrap_is_run;
+	int wrap_is_run(uint32_t flags) {
 		return poldiff_is_run(self, flags);
 	};
 	%newobject get_stats(uint32_t);
-	poldiff_stats_t *get_stats(uint32_t flags) {
+	%rename(get_stats) wrap_get_stats;
+	poldiff_stats_t *wrap_get_stats(uint32_t flags) {
 		poldiff_stats_t *s = NULL;
 		BEGIN_EXCEPTION
 		s = poldiff_stats_create();
@@ -392,7 +395,8 @@ typedef struct poldiff {} poldiff_t;
 		poldiff_stats_destroy(&s);
 		return NULL;
 	};
-	void enable_line_numbers() {
+	%rename(enable_line_numbers) wrap_enable_line_numbers;
+	void wrap_enable_line_numbers() {
 		BEGIN_EXCEPTION
 		if (poldiff_enable_line_numbers(self)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not enable line numbers");
@@ -401,67 +405,88 @@ typedef struct poldiff {} poldiff_t;
 	fail:
 		return;
 	};
-	const apol_vector_t *get_attrib_vector() {
+	%rename(get_attrib_vector) wrap_get_attrib_vector;
+	const apol_vector_t *wrap_get_attrib_vector() {
 		return poldiff_get_attrib_vector(self);
 	};
-	const apol_vector_t *get_avrule_vector_allow() {
+	%rename(get_avrule_vector_allow) wrap_get_avrule_vector_allow;
+	const apol_vector_t *wrap_get_avrule_vector_allow() {
 		return poldiff_get_avrule_vector_allow(self);
 	};
-	const apol_vector_t *get_avrule_vector_auditallow() {
+	%rename(get_avrule_vector_auditallow) wrap_get_avrule_vector_auditallow;
+	const apol_vector_t *wrap_get_avrule_vector_auditallow() {
 		return poldiff_get_avrule_vector_auditallow(self);
 	};
-	const apol_vector_t *get_avrule_vector_dontaudit() {
+	%rename(get_avrule_vector_dontaudit) wrap_get_avrule_vector_dontaudit;
+	const apol_vector_t *wrap_get_avrule_vector_dontaudit() {
 		return poldiff_get_avrule_vector_dontaudit(self);
 	};
-	const apol_vector_t *get_avrule_vector_neverallow() {
+	%rename(get_avrule_vector_neverallow) wrap_get_avrule_vector_neverallow;
+	const apol_vector_t *wrap_get_avrule_vector_neverallow() {
 		return poldiff_get_avrule_vector_neverallow(self);
 	};
-	const apol_vector_t *get_bool_vector() {
+	%rename(get_bool_vector) wrap_get_bool_vector;
+	const apol_vector_t *wrap_get_bool_vector() {
 		return poldiff_get_bool_vector(self);
 	};
-	const apol_vector_t *get_cat_vector() {
+	%rename(get_cat_vector) wrap_get_cat_vector;
+	const apol_vector_t *wrap_get_cat_vector() {
 		return poldiff_get_cat_vector(self);
 	};
-	const apol_vector_t *get_class_vector() {
+	%rename(get_class_vector) wrap_get_class_vector;
+	const apol_vector_t *wrap_get_class_vector() {
 		return poldiff_get_class_vector(self);
 	};
-	const apol_vector_t *get_common_vector() {
+	%rename(get_common_vector) wrap_get_common_vector;
+	const apol_vector_t *wrap_get_common_vector() {
 		return poldiff_get_common_vector(self);
 	};
-	const apol_vector_t *get_level_vector() {
+	%rename(get_level_vector) wrap_get_level_vector;
+	const apol_vector_t *wrap_get_level_vector() {
 		return poldiff_get_level_vector(self);
 	};
-	const apol_vector_t *get_range_trans_vector() {
+	%rename(get_range_trans_vector) wrap_get_range_trans_vector;
+	const apol_vector_t *wrap_get_range_trans_vector() {
 		return poldiff_get_range_trans_vector(self);
 	};
-	const apol_vector_t *get_role_allow_vector() {
+	%rename(get_role_allow_vector) wrap_get_role_allow_vector;
+	const apol_vector_t *wrap_get_role_allow_vector() {
 		return poldiff_get_role_allow_vector(self);
 	};
-	const apol_vector_t *get_role_trans_vector() {
+	%rename(get_role_trans_vector) wrap_get_role_trans_vector;
+	const apol_vector_t *wrap_get_role_trans_vector() {
 		return poldiff_get_role_trans_vector(self);
 	};
-	const apol_vector_t *get_role_vector() {
+	%rename(get_role_vector) wrap_get_role_vector;
+	const apol_vector_t *wrap_get_role_vector() {
 		return poldiff_get_role_vector(self);
 	};
-	const apol_vector_t *get_terule_vector_change() {
+	%rename(get_terule_vector_change) wrap_get_terule_vector_change;
+	const apol_vector_t *wrap_get_terule_vector_change() {
 		return poldiff_get_terule_vector_change(self);
 	};
-	const apol_vector_t *get_terule_vector_member() {
+	%rename(get_terule_vector_member) wrap_get_terule_vector_member;
+	const apol_vector_t *wrap_get_terule_vector_member() {
 		return poldiff_get_terule_vector_member(self);
 	};
-	const apol_vector_t *get_terule_vector_trans() {
+	%rename(get_terule_vector_trans) wrap_get_terule_vector_trans;
+	const apol_vector_t *wrap_get_terule_vector_trans() {
 		return poldiff_get_terule_vector_trans(self);
 	};
-	const apol_vector_t *get_type_vector() {
+	%rename(get_type_vector) wrap_get_type_vector;
+	const apol_vector_t *wrap_get_type_vector() {
 		return poldiff_get_type_vector(self);
 	};
-	const apol_vector_t *get_user_vector() {
+	%rename(get_user_vector) wrap_get_user_vector;
+	const apol_vector_t *wrap_get_user_vector() {
 		return poldiff_get_user_vector(self);
 	};
-	const apol_vector_t *get_type_remap_entries() {
+	%rename(get_type_remap_entries) wrap_get_type_remap_entries;
+	const apol_vector_t *wrap_get_type_remap_entries() {
 		return poldiff_type_remap_get_entries(self);
 	};
-	void type_remap_create(apol_string_vector_t *orig_types, apol_string_vector_t *mod_types) {
+	%rename(type_remap_create) wrap_type_remap_create;
+	void wrap_type_remap_create(apol_string_vector_t *orig_types, apol_string_vector_t *mod_types) {
 		BEGIN_EXCEPTION
 		if (poldiff_type_remap_create(self, (apol_vector_t*)orig_types, (apol_vector_t*)mod_types)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not remap types");
@@ -478,19 +503,20 @@ typedef struct poldiff {} poldiff_t;
 /* attribute diff */
 typedef struct poldiff_attrib {} poldiff_attrib_t;
 %extend poldiff_attrib_t {
-   poldiff_attrib_t () {
+   poldiff_attrib () {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_attrib_t objects");
       END_EXCEPTION
    fail:
       return NULL;
    }
-	~poldiff_attrib_t() {
+	~poldiff_attrib() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_attrib_to_string(p, self);
@@ -501,16 +527,20 @@ typedef struct poldiff_attrib {} poldiff_attrib_t;
 	fail:
 		return str;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return poldiff_attrib_get_name(self);
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_attrib_get_form(self);
 	};
-	const apol_string_vector_t *get_added_types() {
+	%rename(get_added_types) wrap_get_added_types;
+	const apol_string_vector_t *wrap_get_added_types() {
 		return (apol_string_vector_t*)poldiff_attrib_get_added_types(self);
 	};
-	const apol_string_vector_t *get_removed_types() {
+	%rename(get_removed_types) wrap_get_removed_types;
+	const apol_string_vector_t *wrap_get_removed_types() {
 		return (apol_string_vector_t*)poldiff_attrib_get_removed_types(self);
 	};
 };
@@ -523,19 +553,20 @@ typedef struct poldiff_attrib {} poldiff_attrib_t;
 /* av rule diff */
 typedef struct poldiff_avrule {} poldiff_avrule_t;
 %extend poldiff_avrule_t {
-   poldiff_avrule_t() {
+   poldiff_avrule() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_avrule_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_avrule_t() {
+	~poldiff_avrule() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_avrule_to_string(p, self);
@@ -546,22 +577,28 @@ typedef struct poldiff_avrule {} poldiff_avrule_t;
 	fail:
 		return str;
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_avrule_get_form(self);
 	};
-	uint32_t get_rule_type() {
+	%rename(get_rule_type) wrap_get_rule_type;
+	uint32_t wrap_get_rule_type() {
 		return poldiff_avrule_get_rule_type(self);
 	};
-	const char *get_source_type() {
+	%rename(get_source_type) wrap_get_source_type;
+	const char *wrap_get_source_type() {
 		return poldiff_avrule_get_source_type(self);
 	};
-	const char *get_target_type() {
+	%rename(get_target_type) wrap_get_target_type;
+	const char *wrap_get_target_type() {
 		return poldiff_avrule_get_target_type(self);
 	};
-	const char *get_object_class() {
+	%rename(get_object_class) wrap_get_object_class;
+	const char *wrap_get_object_class() {
 		return poldiff_avrule_get_object_class(self);
 	};
-	const qpol_cond_t *get_cond(poldiff_t *p) {
+	%rename(get_cond) wrap_get_cond;
+	const qpol_cond_t *wrap_get_cond(poldiff_t *p) {
 		const qpol_cond_t *cond;
 		uint32_t which_list;
 		const apol_policy_t *which_pol;
@@ -582,20 +619,25 @@ typedef struct poldiff_avrule {} poldiff_avrule_t;
 		poldiff_avrule_get_cond(p, self, &cond, &which_list, &which_pol);
 		return which_pol;
 	};
-	const apol_string_vector_t *get_unmodified_perms() {
+	%rename(get_unmodified_perms) wrap_get_unmodified_perms;
+	const apol_string_vector_t *wrap_get_unmodified_perms() {
 		return (apol_string_vector_t*)poldiff_avrule_get_unmodified_perms(self);
 	};
-	const apol_string_vector_t *get_added_perms() {
+	%rename(get_added_perms) wrap_get_added_perms;
+	const apol_string_vector_t *wrap_get_added_perms() {
 		return (apol_string_vector_t*)poldiff_avrule_get_added_perms(self);
 	};
-	const apol_string_vector_t *get_removed_perms() {
+	%rename(get_removed_perms) wrap_get_removed_perms;
+	const apol_string_vector_t *wrap_get_removed_perms() {
 		return (apol_string_vector_t*)poldiff_avrule_get_removed_perms(self);
 	};
-	const apol_vector_t *get_orig_line_numbers() {
+	%rename(get_orig_line_numbers) wrap_get_orig_line_numbers;
+	const apol_vector_t *wrap_get_orig_line_numbers() {
 		return poldiff_avrule_get_orig_line_numbers(self);
 	};
 	%newobject get_orig_line_numbers_for_perm(poldiff_t*, char*);
-	apol_vector_t *get_orig_line_numbers_for_perm(poldiff_t *p, char *perm) {
+	%rename(get_orig_line_numbers_for_perm) wrap_get_orig_line_numbers_for_perm;
+	apol_vector_t *wrap_get_orig_line_numbers_for_perm(poldiff_t *p, char *perm) {
 		apol_vector_t *v;
 		BEGIN_EXCEPTION
 		v = poldiff_avrule_get_orig_line_numbers_for_perm(p, self, perm);
@@ -606,11 +648,13 @@ typedef struct poldiff_avrule {} poldiff_avrule_t;
 	fail:
 		return v;
 	};
-	const apol_vector_t *get_mod_line_numbers() {
+	%rename(get_mod_line_numbers) wrap_get_mod_line_numbers;
+	const apol_vector_t *wrap_get_mod_line_numbers() {
 		return poldiff_avrule_get_mod_line_numbers(self);
 	};
 	%newobject get_mod_line_numbers_for_perm(poldiff_t*, char*);
-	apol_vector_t *get_mod_line_numbers_for_perm(poldiff_t *p, char *perm) {
+	%rename(get_mod_line_numbers_for_perm) wrap_get_mod_line_numbers_for_perm;
+	apol_vector_t *wrap_get_mod_line_numbers_for_perm(poldiff_t *p, char *perm) {
 		apol_vector_t *v;
 		BEGIN_EXCEPTION
 		v = poldiff_avrule_get_mod_line_numbers_for_perm(p, self, perm);
@@ -631,19 +675,20 @@ typedef struct poldiff_avrule {} poldiff_avrule_t;
 /* boolean diff */
 typedef struct poldiff_bool {} poldiff_bool_t;
 %extend poldiff_bool_t {
-	poldiff_bool_t() {
+	poldiff_bool() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_bool_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_bool_t() {
+	~poldiff_bool() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_bool_to_string(p, self);
@@ -654,10 +699,12 @@ typedef struct poldiff_bool {} poldiff_bool_t;
 	fail:
 		return str;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return poldiff_bool_get_name(self);
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_bool_get_form(self);
 	};
 };
@@ -670,19 +717,20 @@ typedef struct poldiff_bool {} poldiff_bool_t;
 /* category diff */
 typedef struct poldiff_cat {} poldiff_cat_t;
 %extend poldiff_cat_t {
-	poldiff_cat_t() {
+	poldiff_cat() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_cat_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_cat_t() {
+	~poldiff_cat() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_cat_to_string(p, self);
@@ -693,10 +741,12 @@ typedef struct poldiff_cat {} poldiff_cat_t;
 	fail:
 		return str;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return poldiff_cat_get_name(self);
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_cat_get_form(self);
 	};
 };
@@ -709,19 +759,20 @@ typedef struct poldiff_cat {} poldiff_cat_t;
 /* class diff */
 typedef struct poldiff_class {} poldiff_class_t;
 %extend poldiff_class_t {
-	poldiff_class_t() {
+	poldiff_class() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_class_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_class_t() {
+	~poldiff_class() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_class_to_string(p, self);
@@ -732,16 +783,20 @@ typedef struct poldiff_class {} poldiff_class_t;
 	fail:
 		return str;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return poldiff_class_get_name(self);
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_class_get_form(self);
 	};
-	const apol_string_vector_t *get_added_perms() {
+	%rename(get_added_perms) wrap_get_added_perms;
+	const apol_string_vector_t *wrap_get_added_perms() {
 		return (apol_string_vector_t*)poldiff_class_get_added_perms(self);
 	};
-	const apol_string_vector_t *get_removed_perms() {
+	%rename(get_removed_perms) wrap_get_removed_perms;
+	const apol_string_vector_t *wrap_get_removed_perms() {
 		return (apol_string_vector_t*)poldiff_class_get_removed_perms(self);
 	};
 };
@@ -754,19 +809,20 @@ typedef struct poldiff_class {} poldiff_class_t;
 /* common diff */
 typedef struct poldiff_common {} poldiff_common_t;
 %extend poldiff_common_t {
-	poldiff_common_t() {
+	poldiff_common() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_common_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_common_t() {
+	~poldiff_common() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_common_to_string(p, self);
@@ -777,16 +833,20 @@ typedef struct poldiff_common {} poldiff_common_t;
 	fail:
 		return str;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return poldiff_common_get_name(self);
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_common_get_form(self);
 	};
-	const apol_string_vector_t *get_added_perms() {
+	%rename(get_added_perms) wrap_get_added_perms;
+	const apol_string_vector_t *wrap_get_added_perms() {
 		return (apol_string_vector_t*)poldiff_common_get_added_perms(self);
 	};
-	const apol_string_vector_t *get_removed_perms() {
+	%rename(get_removed_perms) wrap_get_removed_perms;
+	const apol_string_vector_t *wrap_get_removed_perms() {
 		return (apol_string_vector_t*)poldiff_common_get_removed_perms(self);
 	};
 };
@@ -799,19 +859,20 @@ typedef struct poldiff_common {} poldiff_common_t;
 /* level diff */
 typedef struct poldiff_level {} poldiff_level_t;
 %extend poldiff_level_t {
-	poldiff_level_t() {
+	poldiff_level() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_level_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_level_t() {
+	~poldiff_level() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_level_to_string(p, self);
@@ -823,7 +884,8 @@ typedef struct poldiff_level {} poldiff_level_t;
 		return str;
 	};
 	%newobject to_string_brief(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string_brief) wrap_to_string_brief;
+	char *wrap_to_string_brief(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_level_to_string_brief(p, self);
@@ -834,19 +896,24 @@ typedef struct poldiff_level {} poldiff_level_t;
 	fail:
 		return str;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return poldiff_level_get_name(self);
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_level_get_form(self);
 	};
-	const apol_string_vector_t *get_unmodified_cats() {
+	%rename(get_unmodified_cats) wrap_get_unmodified_cats;
+	const apol_string_vector_t *wrap_get_unmodified_cats() {
 		return (apol_string_vector_t*)poldiff_level_get_unmodified_cats(self);
 	};
-	const apol_string_vector_t *get_added_cats() {
+	%rename(get_added_cats) wrap_get_added_cats;
+	const apol_string_vector_t *wrap_get_added_cats() {
 		return (apol_string_vector_t*)poldiff_level_get_added_cats(self);
 	};
-	const apol_string_vector_t *get_removed_cats() {
+	%rename(get_removed_cats) wrap_get_removed_cats;
+	const apol_string_vector_t *wrap_get_removed_cats() {
 		return (apol_string_vector_t*)poldiff_level_get_removed_cats(self);
 	};
 };
@@ -859,14 +926,14 @@ typedef struct poldiff_level {} poldiff_level_t;
 /* range diff */
 typedef struct poldiff_range {} poldiff_range_t;
 %extend poldiff_range_t {
-	poldiff_range_t() {
+	poldiff_range() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_range_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_range_t() {
+	~poldiff_range() {
 		/* no op */
 		return;
 	};
@@ -882,22 +949,28 @@ typedef struct poldiff_range {} poldiff_range_t;
 	fail:
 		return str;
 	};
-	const apol_vector_t *get_levels() {
+	%rename(get_levels) wrap_get_levels;
+	const apol_vector_t *wrap_get_levels() {
 		return poldiff_range_get_levels(self);
 	};
-	const apol_mls_range_t *get_original_range() {
+	%rename(get_original_range) wrap_get_original_range;
+	const apol_mls_range_t *wrap_get_original_range() {
 		return poldiff_range_get_original_range(self);
 	};
-	const apol_mls_range_t *get_modified_range() {
+	%rename(get_modified_range) wrap_get_modified_range;
+	const apol_mls_range_t *wrap_get_modified_range() {
 		return poldiff_range_get_modified_range(self);
 	};
-	const apol_string_vector_t *get_min_added_cats() {
+	%rename(get_min_added_cats) wrap_get_min_added_cats;
+	const apol_string_vector_t *wrap_get_min_added_cats() {
 		return (apol_string_vector_t*)poldiff_range_get_min_added_cats(self);
 	};
-	const apol_string_vector_t *get_min_removed_cats() {
+	%rename(get_min_removed_cats) wrap_get_min_removed_cats;
+	const apol_string_vector_t *wrap_get_min_removed_cats() {
 		return (apol_string_vector_t*)poldiff_range_get_min_removed_cats(self);
 	};
-	const apol_string_vector_t *get_min_unmodified_cats() {
+	%rename(get_min_unmodified_cats) wrap_get_min_unmodified_cats;
+	const apol_string_vector_t *wrap_get_min_unmodified_cats() {
 		return (apol_string_vector_t*)poldiff_range_get_min_unmodified_cats(self);
 	};
 };
@@ -910,19 +983,20 @@ typedef struct poldiff_range {} poldiff_range_t;
 /* range_transition rule diff */
 typedef struct poldiff_range_trans {} poldiff_range_trans_t;
 %extend poldiff_range_trans_t {
-	poldiff_range_trans_t() {
+	poldiff_range_trans() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_range_trans_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_range_trans_t() {
+	~poldiff_range_trans() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_range_trans_to_string(p, self);
@@ -933,19 +1007,24 @@ typedef struct poldiff_range_trans {} poldiff_range_trans_t;
 	fail:
 		return str;
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_range_trans_get_form(self);
 	};
-	const char *get_source_type() {
+	%rename(get_source_type) wrap_get_source_type;
+	const char *wrap_get_source_type() {
 		return poldiff_range_trans_get_source_type(self);
 	};
-	const char *get_target_type() {
+	%rename(get_target_type) wrap_get_target_type;
+	const char *wrap_get_target_type() {
 		return poldiff_range_trans_get_target_type(self);
 	};
-	const char *get_target_class() {
+	%rename(get_target_class) wrap_get_target_class;
+	const char *wrap_get_target_class() {
 		return poldiff_range_trans_get_target_class(self);
 	};
-	const poldiff_range_t *get_range() {
+	%rename(get_range) wrap_get_range;
+	const poldiff_range_t *wrap_get_range() {
 		return poldiff_range_trans_get_range(self);
 	};
 };
@@ -958,19 +1037,20 @@ typedef struct poldiff_range_trans {} poldiff_range_trans_t;
 /* role allow rule diff */
 typedef struct poldiff_role_allow {} poldiff_role_allow_t;
 %extend poldiff_role_allow_t {
-	poldiff_role_allow_t() {
+	poldiff_role_allow() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_role_allow_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_role_allow_t() {
+	~poldiff_role_allow() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_role_allow_to_string(p, self);
@@ -981,19 +1061,24 @@ typedef struct poldiff_role_allow {} poldiff_role_allow_t;
 	fail:
 		return str;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return poldiff_role_allow_get_name(self);
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_role_allow_get_form(self);
 	};
-	const apol_string_vector_t *get_unmodified_roles() {
+	%rename(get_unmodified_roles) wrap_get_unmodified_roles;
+	const apol_string_vector_t *wrap_get_unmodified_roles() {
 		return (apol_string_vector_t*)poldiff_role_allow_get_unmodified_roles(self);
 	};
-	const apol_string_vector_t *get_added_roles() {
+	%rename(get_added_roles) wrap_get_added_roles;
+	const apol_string_vector_t *wrap_get_added_roles() {
 		return (apol_string_vector_t*)poldiff_role_allow_get_added_roles(self);
 	};
-	const apol_string_vector_t *get_removed_roles() {
+	%rename(get_removed_roles) wrap_get_removed_roles;
+	const apol_string_vector_t *wrap_get_removed_roles() {
 		return (apol_string_vector_t*)poldiff_role_allow_get_removed_roles(self);
 	};
 };
@@ -1006,19 +1091,20 @@ typedef struct poldiff_role_allow {} poldiff_role_allow_t;
 /* role_transition rule diff */
 typedef struct poldiff_role_trans {} poldiff_role_trans_t;
 %extend poldiff_role_trans_t {
-	poldiff_role_trans_t() {
+	poldiff_role_trans() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_role_trans_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_role_trans_t() {
+	~poldiff_role_trans() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_role_trans_to_string(p, self);
@@ -1029,19 +1115,24 @@ typedef struct poldiff_role_trans {} poldiff_role_trans_t;
 	fail:
 		return str;
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_role_trans_get_form(self);
 	};
-	const char *get_source_role() {
+	%rename(get_source_role) wrap_get_source_role;
+	const char *wrap_get_source_role() {
 		return poldiff_role_trans_get_source_role(self);
 	};
-	const char *get_target_type() {
+	%rename(get_target_type) wrap_get_target_type;
+	const char *wrap_get_target_type() {
 		return poldiff_role_trans_get_target_type(self);
 	};
-	const char *get_original_default() {
+	%rename(get_original_default) wrap_get_original_default;
+	const char *wrap_get_original_default() {
 		return poldiff_role_trans_get_original_default(self);
 	};
-	const char *get_modified_default() {
+	%rename(get_modified_default) wrap_get_modified_default;
+	const char *wrap_get_modified_default() {
 		return poldiff_role_trans_get_modified_default(self);
 	};
 };
@@ -1054,19 +1145,20 @@ typedef struct poldiff_role_trans {} poldiff_role_trans_t;
 /* role diff */
 typedef struct poldiff_role {} poldiff_role_t;
 %extend poldiff_role_t {
-	poldiff_role_t() {
+	poldiff_role() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_role_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_role_t() {
+	~poldiff_role() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_role_to_string(p, self);
@@ -1077,16 +1169,20 @@ typedef struct poldiff_role {} poldiff_role_t;
 	fail:
 		return str;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return poldiff_role_get_name(self);
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_role_get_form(self);
 	};
-	const apol_string_vector_t *get_added_types() {
+	%rename(get_added_types) wrap_get_added_types;
+	const apol_string_vector_t *wrap_get_added_types() {
 		return (apol_string_vector_t*)poldiff_role_get_added_types(self);
 	};
-	const apol_string_vector_t *get_removed_types() {
+	%rename(get_removed_types) wrap_get_removed_types;
+	const apol_string_vector_t *wrap_get_removed_types() {
 		return (apol_string_vector_t*)poldiff_role_get_removed_types(self);
 	};
 };
@@ -1099,19 +1195,20 @@ typedef struct poldiff_role {} poldiff_role_t;
 /* te rule diff */
 typedef struct poldiff_terule {} poldiff_terule_t;
 %extend poldiff_terule_t {
-	poldiff_terule_t() {
+	poldiff_terule() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_terule_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_terule_t() {
+	~poldiff_terule() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_terule_to_string(p, self);
@@ -1122,22 +1219,28 @@ typedef struct poldiff_terule {} poldiff_terule_t;
 	fail:
 		return str;
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_terule_get_form(self);
 	};
-	uint32_t get_rule_type() {
+	%rename(get_rule_type) wrap_get_rule_type;
+	uint32_t wrap_get_rule_type() {
 		return poldiff_terule_get_rule_type(self);
 	};
-	const char *get_source_type() {
+	%rename(get_source_type) wrap_get_source_type;
+	const char *wrap_get_source_type() {
 		return poldiff_terule_get_source_type(self);
 	};
-	const char *get_target_type() {
+	%rename(get_target_type) wrap_get_target_type;
+	const char *wrap_get_target_type() {
 		return poldiff_terule_get_target_type(self);
 	};
-	const char *get_object_class() {
+	%rename(get_object_class) wrap_get_object_class;
+	const char *wrap_get_object_class() {
 		return poldiff_terule_get_object_class(self);
 	};
-	const qpol_cond_t *get_cond(poldiff_t *p) {
+	%rename(get_cond) wrap_get_cond;
+	const qpol_cond_t *wrap_get_cond(poldiff_t *p) {
 		const qpol_cond_t *cond;
 		uint32_t which_list;
 		const apol_policy_t *which_pol;
@@ -1158,16 +1261,20 @@ typedef struct poldiff_terule {} poldiff_terule_t;
 		poldiff_terule_get_cond(p, self, &cond, &which_list, &which_pol);
 		return which_pol;
 	};
-	const char *get_original_default() {
+	%rename(get_original_default) wrap_get_original_default;
+	const char *wrap_get_original_default() {
 		return poldiff_terule_get_original_default(self);
 	};
-	const char *get_modified_default() {
+	%rename(get_modified_default) wrap_get_modified_default;
+	const char *wrap_get_modified_default() {
 		return poldiff_terule_get_modified_default(self);
 	};
-	const apol_vector_t *get_orig_line_numbers() {
+	%rename(get_orig_line_numbers) wrap_get_orig_line_numbers;
+	const apol_vector_t *wrap_get_orig_line_numbers() {
 		return poldiff_terule_get_orig_line_numbers(self);
 	};
-	const apol_vector_t *get_mod_line_numbers() {
+	%rename(get_mod_line_numbers) wrap_get_mod_line_numbers;
+	const apol_vector_t *wrap_get_mod_line_numbers() {
 		return poldiff_terule_get_mod_line_numbers(self);
 	};
 };
@@ -1180,19 +1287,20 @@ typedef struct poldiff_terule {} poldiff_terule_t;
 /* type diff */
 typedef struct poldiff_type {} poldiff_type_t;
 %extend poldiff_type_t {
-	poldiff_type_t() {
+	poldiff_type() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_type_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_type_t() {
+	~poldiff_type() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_type_to_string(p, self);
@@ -1203,16 +1311,20 @@ typedef struct poldiff_type {} poldiff_type_t;
 	fail:
 		return str;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return poldiff_type_get_name(self);
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_type_get_form(self);
 	};
-	const apol_string_vector_t *get_added_attribs() {
+	%rename(get_added_attribs) wrap_get_added_attribs;
+	const apol_string_vector_t *wrap_get_added_attribs() {
 		return (apol_string_vector_t*)poldiff_type_get_added_attribs(self);
 	};
-	const apol_string_vector_t *get_removed_attribs() {
+	%rename(get_removed_attribs) wrap_get_removed_attribs;
+	const apol_string_vector_t *wrap_get_removed_attribs() {
 		return (apol_string_vector_t*)poldiff_type_get_removed_attribs(self);
 	};
 };
@@ -1225,19 +1337,20 @@ typedef struct poldiff_type {} poldiff_type_t;
 /* user diff */
 typedef struct poldiff_user {} poldiff_user_t;
 %extend poldiff_user_t {
-	poldiff_user_t() {
+	poldiff_user() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_user_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_user_t() {
+	~poldiff_user() {
 		/* no op */
 		return;
 	};
 	%newobject to_string(poldiff_t*);
-	char *to_string(poldiff_t *p) {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string(poldiff_t *p) {
 		char *str;
 		BEGIN_EXCEPTION
 		str = poldiff_user_to_string(p, self);
@@ -1248,28 +1361,36 @@ typedef struct poldiff_user {} poldiff_user_t;
 	fail:
 		return str;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return poldiff_user_get_name(self);
 	};
-	poldiff_form_e get_form() {
+	%rename(get_form) wrap_get_form;
+	poldiff_form_e wrap_get_form() {
 		return poldiff_user_get_form(self);
 	};
-	const apol_string_vector_t *get_unmodified_roles() {
+	%rename(get_unmodified_roles) wrap_get_unmodified_roles;
+	const apol_string_vector_t *wrap_get_unmodified_roles() {
 		return (apol_string_vector_t*)poldiff_user_get_unmodified_roles(self);
 	};
-	const apol_string_vector_t *get_added_roles() {
+	%rename(get_added_roles) wrap_get_added_roles;
+	const apol_string_vector_t *wrap_get_added_roles() {
 		return (apol_string_vector_t*)poldiff_user_get_added_roles(self);
 	};
-	const apol_string_vector_t *get_removed_roles() {
+	%rename(get_removed_roles) wrap_get_removed_roles;
+	const apol_string_vector_t *wrap_get_removed_roles() {
 		return (apol_string_vector_t*)poldiff_user_get_removed_roles(self);
 	};
-	const poldiff_level_t *get_original_dfltlevel() {
+	%rename(get_original_dfltlevel) wrap_get_original_dfltlevel;
+	const poldiff_level_t *wrap_get_original_dfltlevel() {
 		return poldiff_user_get_original_dfltlevel(self);
 	};
-	const poldiff_level_t *get_modified_dfltlevel() {
+	%rename(get_modified_dfltlevel) wrap_get_modified_dfltlevel;
+	const poldiff_level_t *wrap_get_modified_dfltlevel() {
 		return poldiff_user_get_modified_dfltlevel(self);
 	};
-	const poldiff_range_t *get_range() {
+	%rename(get_range) wrap_get_range;
+	const poldiff_range_t *wrap_get_range() {
 		return poldiff_user_get_range(self);
 	};
 };
@@ -1282,19 +1403,20 @@ typedef struct poldiff_user {} poldiff_user_t;
 /* type remap */
 typedef struct poldiff_type_remap_entry {} poldiff_type_remap_entry_t;
 %extend poldiff_type_remap_entry_t {
-	poldiff_type_remap_entry_t() {
+	poldiff_type_remap_entry() {
       BEGIN_EXCEPTION
       SWIG_exception(SWIG_RuntimeError, "Cannot directly create poldiff_type_remap_entry_t objects");
       END_EXCEPTION
    fail:
       return NULL;
  	}
-	~poldiff_type_remap_entry_t() {
+	~poldiff_type_remap_entry() {
 		/* no op */
 		return;
 	};
 	%newobject get_original_types(poldiff_t*);
-	apol_string_vector_t *get_original_types(poldiff_t *p) {
+	%rename(get_original_types) wrap_get_original_types;
+	apol_string_vector_t *wrap_get_original_types(poldiff_t *p) {
 		apol_vector_t *v;
 		BEGIN_EXCEPTION
 		v = poldiff_type_remap_entry_get_original_types(p, self);
@@ -1306,7 +1428,8 @@ typedef struct poldiff_type_remap_entry {} poldiff_type_remap_entry_t;
 		return (apol_string_vector_t*)v;
 	};
 	%newobject get_modified_types(poldiff_t*);
-	apol_string_vector_t *get_modified_types(poldiff_t *p) {
+	%rename(get_modified_types) wrap_get_modified_types;
+	apol_string_vector_t *wrap_get_modified_types(poldiff_t *p) {
 		apol_vector_t *v;
 		BEGIN_EXCEPTION
 		v = poldiff_type_remap_entry_get_modified_types(p, self);
@@ -1317,13 +1440,16 @@ typedef struct poldiff_type_remap_entry {} poldiff_type_remap_entry_t;
 	fail:
 		return (apol_string_vector_t*)v;
 	};
-	int get_is_inferred() {
+	%rename(get_is_inferred) wrap_get_is_inferred;
+	int wrap_get_is_inferred() {
 		return poldiff_type_remap_entry_get_is_inferred(self);
 	};
-	int get_is_enabled() {
+	%rename(get_is_enabled) wrap_get_is_enabled;
+	int wrap_get_is_enabled() {
 		return poldiff_type_remap_entry_get_is_enabled(self);
 	};
-	void set_enabled(int enable) {
+	%rename(set_enabled) wrap_set_enabled;
+	void wrap_set_enabled(int enable) {
 		poldiff_type_remap_entry_set_enabled(self, enable);
 	};
 };

--- a/libqpol/swig/qpol.i
+++ b/libqpol/swig/qpol.i
@@ -228,7 +228,7 @@ SWIGEXPORT int Tqpol_Init(Tcl_Interp *interp) {
 #define QPOL_MODULE_OTHER   2
 typedef struct qpol_module {} qpol_module_t;
 %extend qpol_module_t {
-	qpol_module_t(const char *path) {
+	qpol_module(const char *path) {
 		qpol_module_t *m;
 		BEGIN_EXCEPTION
 		if (qpol_module_create_from_file(path, &m)) {
@@ -239,10 +239,11 @@ typedef struct qpol_module {} qpol_module_t;
 	fail:
 		return NULL;
 	};
-	~qpol_module_t() {
+	~qpol_module() {
 		qpol_module_destroy(&self);
 	};
-	const char *get_path() {
+	%rename(get_path) wrap_get_path;
+	const char *wrap_get_path() {
 		const char *p;
 		BEGIN_EXCEPTION
 		if (qpol_module_get_path(self, &p)) {
@@ -253,7 +254,8 @@ typedef struct qpol_module {} qpol_module_t;
 	fail:
 		return NULL;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		const char *n;
 		BEGIN_EXCEPTION
 		if (qpol_module_get_name(self, &n)) {
@@ -264,7 +266,8 @@ typedef struct qpol_module {} qpol_module_t;
 	fail:
 			return NULL;
 	};
-	const char *get_version() {
+	%rename(get_version) wrap_get_version;
+	const char *wrap_get_version() {
 		const char *v;
 		BEGIN_EXCEPTION
 		if (qpol_module_get_version(self, &v)) {
@@ -275,7 +278,8 @@ typedef struct qpol_module {} qpol_module_t;
 	fail:
 			return NULL;
 	};
-	int get_type() {
+	%rename(get_type) wrap_get_type;
+	int wrap_get_type() {
 		int t;
 		BEGIN_EXCEPTION
 		if (qpol_module_get_type(self, &t)) {
@@ -285,7 +289,8 @@ typedef struct qpol_module {} qpol_module_t;
 	fail:
 		return t;
 	};
-	int get_enabled() {
+	%rename(get_enabled) wrap_get_enabled;
+	int wrap_get_enabled() {
 		int e;
 		BEGIN_EXCEPTION
 		if (qpol_module_get_enabled(self, &e)) {
@@ -295,7 +300,8 @@ typedef struct qpol_module {} qpol_module_t;
 	fail:
 			return e;
 	};
-	void set_enabled(int state) {
+	%rename(set_enabled) wrap_set_enabled;
+	void wrap_set_enabled(int state) {
 		BEGIN_EXCEPTION
 		if (qpol_module_set_enabled(self, state)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set module state");
@@ -337,7 +343,7 @@ typedef enum qpol_capability
 } qpol_capability_e;
 
 %extend qpol_policy_t {
-	qpol_policy_t(const char *path, const int options) {
+	qpol_policy(const char *path, const int options) {
 		qpol_policy_t *p;
 		BEGIN_EXCEPTION
 		if (qpol_policy_open_from_file(path, &p, qpol_swig_message_callback, qpol_swig_message_callback_arg, options) < 0) {
@@ -348,10 +354,11 @@ typedef enum qpol_capability
 	fail:
 		return NULL;
 	}
-	~qpol_policy_t() {
+	~qpol_policy() {
 		qpol_policy_destroy(&self);
 	};
-	void reevaluate_conds() {
+	%rename(reevaluate_conds) wrap_reevaluate_conds;
+	void wrap_reevaluate_conds() {
 		BEGIN_EXCEPTION
 		if (qpol_policy_reevaluate_conds(self)) {
 			SWIG_exception(SWIG_ValueError, "Error evaluating conditional expressions");
@@ -360,7 +367,8 @@ typedef enum qpol_capability
 	fail:
 		return;
 	};
-	void append_module(qpol_module_t *mod) {
+	%rename(append_module) wrap_append_module;
+	void wrap_append_module(qpol_module_t *mod) {
 		BEGIN_EXCEPTION
 		if (qpol_policy_append_module(self, mod)) {
 			SWIG_exception(SWIG_MemoryError, "Out of Memory");
@@ -369,7 +377,8 @@ typedef enum qpol_capability
 	fail:
 		return;
 	};
-	void rebuild (const int options) {
+	%rename(rebuild) wrap_rebuild;
+	void wrap_rebuild (const int options) {
 		BEGIN_EXCEPTION
 		if (qpol_policy_rebuild(self, options)) {
 			SWIG_exception(SWIG_RuntimeError, "Failed rebuilding policy");
@@ -390,15 +399,18 @@ typedef enum qpol_capability
 		return (int) h;
 	};
 
-	int get_type () {
+	%rename(get_type) wrap_get_type;
+	int wrap_get_type () {
 		int t;
 		(void)qpol_policy_get_type(self, &t); /* only error is on null parameters neither can be here */
 		return t;
 	};
-	int has_capability (qpol_capability_e cap) {
+	%rename(has_capability) wrap_has_capability;
+	int wrap_has_capability (qpol_capability_e cap) {
 		return qpol_policy_has_capability(self, cap);
 	};
-	void build_syn_rule_table() {
+	%rename(build_syn_rule_table) wrap_build_syn_rule_table;
+	void wrap_build_syn_rule_table() {
 		BEGIN_EXCEPTION
 		if (qpol_policy_build_syn_rule_table(self)) {
 			SWIG_exception(SWIG_MemoryError, "Out of Memory");
@@ -408,7 +420,8 @@ typedef enum qpol_capability
 		return;
 	};
 	%newobject get_module_iter();
-	qpol_iterator_t *get_module_iter() {
+	%rename(get_module_iter) wrap_get_module_iter;
+	qpol_iterator_t *wrap_get_module_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_module_iter(self, &iter)) {
@@ -420,7 +433,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_type_iter();
-	qpol_iterator_t *get_type_iter() {
+	%rename(get_type_iter) wrap_get_type_iter;
+	qpol_iterator_t *wrap_get_type_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_type_iter(self, &iter)) {
@@ -432,7 +446,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_role_iter();
-	qpol_iterator_t *get_role_iter() {
+	%rename(get_role_iter) wrap_get_role_iter;
+	qpol_iterator_t *wrap_get_role_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_role_iter(self, &iter)) {
@@ -444,7 +459,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_level_iter();
-	qpol_iterator_t *get_level_iter() {
+	%rename(get_level_iter) wrap_get_level_iter;
+	qpol_iterator_t *wrap_get_level_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_level_iter(self, &iter)) {
@@ -456,7 +472,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_cat_iter();
-	qpol_iterator_t *get_cat_iter() {
+	%rename(get_cat_iter) wrap_get_cat_iter;
+	qpol_iterator_t *wrap_get_cat_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_cat_iter(self, &iter)) {
@@ -468,7 +485,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_user_iter();
-	qpol_iterator_t *get_user_iter() {
+	%rename(get_user_iter) wrap_get_user_iter;
+	qpol_iterator_t *wrap_get_user_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_user_iter(self, &iter)) {
@@ -480,7 +498,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_bool_iter();
-	qpol_iterator_t *get_bool_iter() {
+	%rename(get_bool_iter) wrap_get_bool_iter;
+	qpol_iterator_t *wrap_get_bool_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_bool_iter(self, &iter)) {
@@ -492,7 +511,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_class_iter(char*);
-	qpol_iterator_t *get_class_iter(char *perm=NULL) {
+	%rename(get_class_iter) wrap_get_class_iter;
+	qpol_iterator_t *wrap_get_class_iter(char *perm=NULL) {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (perm) {
@@ -510,7 +530,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_common_iter(char*);
-	qpol_iterator_t *get_common_iter(char *perm=NULL) {
+	%rename(get_common_iter) wrap_get_common_iter;
+	qpol_iterator_t *wrap_get_common_iter(char *perm=NULL) {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (perm) {
@@ -528,7 +549,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_fs_use_iter();
-	qpol_iterator_t *get_fs_use_iter() {
+	%rename(get_fs_use_iter) wrap_get_fs_use_iter;
+	qpol_iterator_t *wrap_get_fs_use_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_fs_use_iter(self, &iter)) {
@@ -540,7 +562,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_genfscon_iter();
-	qpol_iterator_t *get_genfscon_iter() {
+	%rename(get_genfscon_iter) wrap_get_genfscon_iter;
+	qpol_iterator_t *wrap_get_genfscon_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_genfscon_iter(self, &iter)) {
@@ -552,7 +575,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_isid_iter();
-	qpol_iterator_t *get_isid_iter() {
+	%rename(get_isid_iter) wrap_get_isid_iter;
+	qpol_iterator_t *wrap_get_isid_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_isid_iter(self, &iter)) {
@@ -564,7 +588,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_netifcon_iter();
-	qpol_iterator_t *get_netifcon_iter() {
+	%rename(get_netifcon_iter) wrap_get_netifcon_iter;
+	qpol_iterator_t *wrap_get_netifcon_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_netifcon_iter(self, &iter)) {
@@ -576,7 +601,8 @@ typedef enum qpol_capability
 			return NULL;
 	};
 	%newobject get_nodecon_iter();
-	qpol_iterator_t *get_nodecon_iter() {
+	%rename(get_nodecon_iter) wrap_get_nodecon_iter;
+	qpol_iterator_t *wrap_get_nodecon_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_nodecon_iter(self, &iter)) {
@@ -588,7 +614,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_portcon_iter();
-	qpol_iterator_t *get_portcon_iter() {
+	%rename(get_portcon_iter) wrap_get_portcon_iter;
+	qpol_iterator_t *wrap_get_portcon_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_portcon_iter(self, &iter)) {
@@ -600,7 +627,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_constraint_iter();
-	qpol_iterator_t *get_constraint_iter() {
+	%rename(get_constraint_iter) wrap_get_constraint_iter;
+	qpol_iterator_t *wrap_get_constraint_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_constraint_iter(self, &iter)) {
@@ -612,7 +640,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_validatetrans_iter();
-	qpol_iterator_t *get_validatetrans_iter() {
+	%rename(get_validatetrans_iter) wrap_get_validatetrans_iter;
+	qpol_iterator_t *wrap_get_validatetrans_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_validatetrans_iter(self, &iter)) {
@@ -624,7 +653,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_role_allow_iter();
-	qpol_iterator_t *get_role_allow_iter() {
+	%rename(get_role_allow_iter) wrap_get_role_allow_iter;
+	qpol_iterator_t *wrap_get_role_allow_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_role_allow_iter(self, &iter)) {
@@ -636,7 +666,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_role_trans_iter();
-	qpol_iterator_t *get_role_trans_iter() {
+	%rename(get_role_trans_iter) wrap_get_role_trans_iter;
+	qpol_iterator_t *wrap_get_role_trans_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_role_trans_iter(self, &iter)) {
@@ -648,7 +679,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_range_trans_iter();
-	qpol_iterator_t *get_range_trans_iter() {
+	%rename(get_range_trans_iter) wrap_get_range_trans_iter;
+	qpol_iterator_t *wrap_get_range_trans_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_range_trans_iter(self, &iter)) {
@@ -660,7 +692,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_avrule_iter(int);
-	qpol_iterator_t *get_avrule_iter(int rule_types) {
+	%rename(get_avrule_iter) wrap_get_avrule_iter;
+	qpol_iterator_t *wrap_get_avrule_iter(int rule_types) {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_avrule_iter(self, rule_types, &iter)) {
@@ -672,7 +705,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_terule_iter(int);
-	qpol_iterator_t *get_terule_iter(int rule_types) {
+	%rename(get_terule_iter) wrap_get_terule_iter;
+	qpol_iterator_t *wrap_get_terule_iter(int rule_types) {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_terule_iter(self, rule_types, &iter)) {
@@ -684,7 +718,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_cond_iter();
-	qpol_iterator_t *get_cond_iter() {
+	%rename(get_cond_iter) wrap_get_cond_iter;
+	qpol_iterator_t *wrap_get_cond_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_cond_iter(self, &iter)) {
@@ -696,7 +731,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_filename_trans_iter();
-	qpol_iterator_t *get_filename_trans_iter() {
+	%rename(get_filename_trans_iter) wrap_get_filename_trans_iter;
+	qpol_iterator_t *wrap_get_filename_trans_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_filename_trans_iter(self, &iter)) {
@@ -708,7 +744,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_permissive_iter();
-	qpol_iterator_t *get_permissive_iter() {
+	%rename(get_permissive_iter) wrap_get_permissive_iter;
+	qpol_iterator_t *wrap_get_permissive_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_permissive_iter(self, &iter)) {
@@ -720,7 +757,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_typebounds_iter();
-	qpol_iterator_t *get_typebounds_iter() {
+	%rename(get_typebounds_iter) wrap_get_typebounds_iter;
+	qpol_iterator_t *wrap_get_typebounds_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_typebounds_iter(self, &iter)) {
@@ -732,7 +770,8 @@ typedef enum qpol_capability
 		return NULL;
 	};
 	%newobject get_polcap_iter();
-	qpol_iterator_t *get_polcap_iter() {
+	%rename(get_polcap_iter) wrap_get_polcap_iter;
+	qpol_iterator_t *wrap_get_polcap_iter() {
 		BEGIN_EXCEPTION
 		qpol_iterator_t *iter;
 		if (qpol_policy_get_polcap_iter(self, &iter)) {
@@ -749,17 +788,18 @@ typedef enum qpol_capability
 typedef struct qpol_iterator {} qpol_iterator_t;
 %extend qpol_iterator_t {
 	/* user never directly creates, but SWIG expects a constructor */
-	qpol_iterator_t() {
+	qpol_iterator() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_TypeError, "User may not create iterators difectly");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_iterator_t() {
+	~qpol_iterator() {
 		qpol_iterator_destroy(&self);
 	};
-	void *get_item() {
+	%rename(get_item) wrap_get_item;
+	void *wrap_get_item() {
 		BEGIN_EXCEPTION
 		void *i;
 		if (qpol_iterator_get_item(self, &i)) {
@@ -770,7 +810,8 @@ typedef struct qpol_iterator {} qpol_iterator_t;
 	fail:
 		return NULL;
 	};
-	void next() {
+	%rename(next) wrap_next;
+	void wrap_next() {
 		BEGIN_EXCEPTION
 		if (qpol_iterator_next(self)) {
 			SWIG_exception(SWIG_RuntimeError, "Error advancing iterator");
@@ -779,10 +820,12 @@ typedef struct qpol_iterator {} qpol_iterator_t;
 	fail:
 		return;
 	};
-	int end() {
+	%rename(end) wrap_end;
+	int wrap_end() {
 		return qpol_iterator_end(self);
 	};
-	size_t get_size() {
+	%rename(get_size) wrap_get_size;
+	size_t wrap_get_size() {
 		BEGIN_EXCEPTION
 		size_t s;
 		if (qpol_iterator_get_size(self, &s)) {
@@ -798,7 +841,7 @@ typedef struct qpol_iterator {} qpol_iterator_t;
 /* qpol type */
 typedef struct qpol_type {} qpol_type_t;
 %extend qpol_type_t {
-	qpol_type_t(qpol_policy_t *p, const char *name) {
+	qpol_type(qpol_policy_t *p, const char *name) {
 		BEGIN_EXCEPTION
 		const qpol_type_t *t;
 		if (qpol_policy_get_type_by_name(p, name, &t)) {
@@ -809,11 +852,12 @@ typedef struct qpol_type {} qpol_type_t;
 	fail:
 		return NULL;
 	};
-	~qpol_type_t() {
+	~qpol_type() {
 		/* no op */
 		return;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		BEGIN_EXCEPTION
 		const char *name;
 		if (qpol_type_get_name(p, self, &name)) {
@@ -824,7 +868,8 @@ typedef struct qpol_type {} qpol_type_t;
 	fail:
 		return NULL;
 	};
-	int get_value(qpol_policy_t *p) {
+	%rename(get_value) wrap_get_value;
+	int wrap_get_value(qpol_policy_t *p) {
 		uint32_t v;
 		BEGIN_EXCEPTION
 		if (qpol_type_get_value(p, self, &v)) {
@@ -834,7 +879,8 @@ typedef struct qpol_type {} qpol_type_t;
 	fail:
 		return (int) v;
 	};
-	int get_isalias(qpol_policy_t *p) {
+	%rename(get_isalias) wrap_get_isalias;
+	int wrap_get_isalias(qpol_policy_t *p) {
 		unsigned char i;
 		BEGIN_EXCEPTION
 		if (qpol_type_get_isalias(p, self, &i)) {
@@ -844,7 +890,8 @@ typedef struct qpol_type {} qpol_type_t;
 	fail:
 		return (int)i;
 	};
-	int get_isattr(qpol_policy_t *p) {
+	%rename(get_isattr) wrap_get_isattr;
+	int wrap_get_isattr(qpol_policy_t *p) {
 		unsigned char i;
 		BEGIN_EXCEPTION
 		if (qpol_type_get_isattr(p, self, &i)) {
@@ -854,7 +901,8 @@ typedef struct qpol_type {} qpol_type_t;
 	fail:
 		return (int)i;
 	};
-	int get_ispermissive(qpol_policy_t *p) {
+	%rename(get_ispermissive) wrap_get_ispermissive;
+	int wrap_get_ispermissive(qpol_policy_t *p) {
 		unsigned char i;
 		BEGIN_EXCEPTION
 		if (qpol_type_get_ispermissive(p, self, &i)) {
@@ -865,7 +913,8 @@ typedef struct qpol_type {} qpol_type_t;
 		return (int)i;
 	};
 	%newobject get_type_iter(qpol_policy_t*);
-	qpol_iterator_t *get_type_iter(qpol_policy_t *p) {
+	%rename(get_type_iter) wrap_get_type_iter;
+	qpol_iterator_t *wrap_get_type_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		int retv = qpol_type_get_type_iter(p, self, &iter);
@@ -879,7 +928,8 @@ typedef struct qpol_type {} qpol_type_t;
 		return iter;
 	};
 	%newobject get_attr_iter(qpol_policy_t*);
-	qpol_iterator_t *get_attr_iter(qpol_policy_t *p) {
+	%rename(get_attr_iter) wrap_get_attr_iter;
+	qpol_iterator_t *wrap_get_attr_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		int retv = qpol_type_get_attr_iter(p, self, &iter);
@@ -893,7 +943,8 @@ typedef struct qpol_type {} qpol_type_t;
 		return iter;
 	};
 	%newobject get_alias_iter(qpol_policy_t*);
-	qpol_iterator_t *get_alias_iter(qpol_policy_t *p) {
+	%rename(get_alias_iter) wrap_get_alias_iter;
+	qpol_iterator_t *wrap_get_alias_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_type_get_alias_iter(p, self, &iter)) {
@@ -903,7 +954,8 @@ typedef struct qpol_type {} qpol_type_t;
 	fail:
 		return iter;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		BEGIN_EXCEPTION
 		const char *name;
 		if (qpol_permissive_get_name(p, self, &name)) {
@@ -924,7 +976,7 @@ typedef struct qpol_type {} qpol_type_t;
 /* qpol role */
 typedef struct qpol_role {} qpol_role_t;
 %extend qpol_role_t {
-	qpol_role_t(qpol_policy_t *p, const char *name) {
+	qpol_role(qpol_policy_t *p, const char *name) {
 		const qpol_role_t *r;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_role_by_name(p, name, &r)) {
@@ -935,11 +987,12 @@ typedef struct qpol_role {} qpol_role_t;
 	fail:
 		return NULL;
 	};
-	~qpol_role_t() {
+	~qpol_role() {
 		/* no op */
 		return;
 	};
-	int get_value (qpol_policy_t *p) {
+	%rename(get_value) wrap_get_value;
+	int wrap_get_value (qpol_policy_t *p) {
 		uint32_t v;
 		BEGIN_EXCEPTION
 		if (qpol_role_get_value(p, self, &v)) {
@@ -949,7 +1002,8 @@ typedef struct qpol_role {} qpol_role_t;
 	fail:
 		return (int) v;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_role_get_name(p, self, &name)) {
@@ -961,7 +1015,8 @@ typedef struct qpol_role {} qpol_role_t;
 		return NULL;
 	};
 	%newobject get_type_iter(qpol_policy_t*);
-	qpol_iterator_t *get_type_iter(qpol_policy_t *p) {
+	%rename(get_type_iter) wrap_get_type_iter;
+	qpol_iterator_t *wrap_get_type_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_role_get_type_iter(p, self, &iter)) {
@@ -972,7 +1027,8 @@ typedef struct qpol_role {} qpol_role_t;
 		return iter;
 	};
 	%newobject get_dominate_iter(qpol_policy_t*);
-	qpol_iterator_t *get_dominate_iter(qpol_policy_t *p) {
+	%rename(get_dominate_iter) wrap_get_dominate_iter;
+	qpol_iterator_t *wrap_get_dominate_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_role_get_dominate_iter(p, self, &iter)) {
@@ -992,7 +1048,7 @@ typedef struct qpol_role {} qpol_role_t;
 /* qpol level */
 typedef struct qpol_level {} qpol_level_t;
 %extend qpol_level_t {
-	qpol_level_t(qpol_policy_t *p, const char *name) {
+	qpol_level(qpol_policy_t *p, const char *name) {
 		const qpol_level_t *l;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_level_by_name(p, name, &l)) {
@@ -1003,11 +1059,12 @@ typedef struct qpol_level {} qpol_level_t;
 	fail:
 		return NULL;
 	};
-	~qpol_level_t() {
+	~qpol_level() {
 		/* no op */
 		return;
 	};
-	int get_isalias(qpol_policy_t *p) {
+	%rename(get_isalias) wrap_get_isalias;
+	int wrap_get_isalias(qpol_policy_t *p) {
 		unsigned char i;
 		BEGIN_EXCEPTION
 		if (qpol_level_get_isalias(p, self, &i)) {
@@ -1017,7 +1074,8 @@ typedef struct qpol_level {} qpol_level_t;
 	fail:
 			return (int)i;
 	};
-	int get_value(qpol_policy_t *p) {
+	%rename(get_value) wrap_get_value;
+	int wrap_get_value(qpol_policy_t *p) {
 		uint32_t v;
 		BEGIN_EXCEPTION
 		if (qpol_level_get_value(p, self, &v)) {
@@ -1027,7 +1085,8 @@ typedef struct qpol_level {} qpol_level_t;
 	fail:
 		return (int) v;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_level_get_name(p, self, &name)) {
@@ -1039,7 +1098,8 @@ typedef struct qpol_level {} qpol_level_t;
 		return NULL;
 	};
 	%newobject get_cat_iter(qpol_policy_t*);
-	qpol_iterator_t *get_cat_iter(qpol_policy_t *p) {
+	%rename(get_cat_iter) wrap_get_cat_iter;
+	qpol_iterator_t *wrap_get_cat_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_level_get_cat_iter(p, self, &iter)) {
@@ -1050,7 +1110,8 @@ typedef struct qpol_level {} qpol_level_t;
 		return iter;
 	};
 	%newobject get_alias_iter(qpol_policy_t*);
-	qpol_iterator_t *get_alias_iter(qpol_policy_t *p) {
+	%rename(get_alias_iter) wrap_get_alias_iter;
+	qpol_iterator_t *wrap_get_alias_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_level_get_alias_iter(p, self, &iter)) {
@@ -1070,7 +1131,7 @@ typedef struct qpol_level {} qpol_level_t;
 /* qpol cat */
 typedef struct qpol_cat {} qpol_cat_t;
 %extend qpol_cat_t {
-	qpol_cat_t(qpol_policy_t *p, const char *name) {
+	qpol_cat(qpol_policy_t *p, const char *name) {
 		const qpol_cat_t *c;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_cat_by_name(p, name, &c)) {
@@ -1081,11 +1142,12 @@ typedef struct qpol_cat {} qpol_cat_t;
 	fail:
 		return NULL;
 	};
-	~qpol_cat_t() {
+	~qpol_cat() {
 		/* no op */
 		return;
 	};
-	int get_isalias(qpol_policy_t *p) {
+	%rename(get_isalias) wrap_get_isalias;
+	int wrap_get_isalias(qpol_policy_t *p) {
 		unsigned char i;
 		BEGIN_EXCEPTION
 		if (qpol_cat_get_isalias(p, self, &i)) {
@@ -1095,7 +1157,8 @@ typedef struct qpol_cat {} qpol_cat_t;
 	fail:
 			return (int)i;
 	};
-	int get_value(qpol_policy_t *p) {
+	%rename(get_value) wrap_get_value;
+	int wrap_get_value(qpol_policy_t *p) {
 		uint32_t v;
 		BEGIN_EXCEPTION
 		if (qpol_cat_get_value(p, self, &v)) {
@@ -1105,7 +1168,8 @@ typedef struct qpol_cat {} qpol_cat_t;
 	fail:
 		return (int) v;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_cat_get_name(p, self, &name)) {
@@ -1117,7 +1181,8 @@ typedef struct qpol_cat {} qpol_cat_t;
 		return NULL;
 	};
 	%newobject get_alias_iter(qpol_policy_t*);
-	qpol_iterator_t *get_alias_iter(qpol_policy_t *p) {
+	%rename(get_alias_iter) wrap_get_alias_iter;
+	qpol_iterator_t *wrap_get_alias_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_cat_get_alias_iter(p, self, &iter)) {
@@ -1137,18 +1202,19 @@ typedef struct qpol_cat {} qpol_cat_t;
 /* qpol mls range */
 typedef struct qpol_mls_range {} qpol_mls_range_t;
 %extend qpol_mls_range_t {
-	qpol_mls_range_t() {
+	qpol_mls_range() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_mls_range_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	}
-	~qpol_mls_range_t() {
+	~qpol_mls_range() {
 		/* no op */
 		return;
 	};
-	const qpol_mls_level_t *get_high_level(qpol_policy_t *p) {
+	%rename(get_high_level) wrap_get_high_level;
+	const qpol_mls_level_t *wrap_get_high_level(qpol_policy_t *p) {
 		const qpol_mls_level_t *l;
 		BEGIN_EXCEPTION
 		if (qpol_mls_range_get_high_level(p, self, &l)) {
@@ -1158,7 +1224,8 @@ typedef struct qpol_mls_range {} qpol_mls_range_t;
 	fail:
 		return l;
 	};
-	const qpol_mls_level_t *get_low_level(qpol_policy_t *p) {
+	%rename(get_low_level) wrap_get_low_level;
+	const qpol_mls_level_t *wrap_get_low_level(qpol_policy_t *p) {
 		const qpol_mls_level_t *l;
 		BEGIN_EXCEPTION
 		if (qpol_mls_range_get_low_level(p, self, &l)) {
@@ -1178,18 +1245,19 @@ typedef struct qpol_mls_range {} qpol_mls_range_t;
 /* qpol mls level */
 typedef struct qpol_mls_level {} qpol_mls_level_t;
 %extend qpol_mls_level_t {
-	qpol_mls_level_t() {
+	qpol_mls_level() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_mls_level_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	}
-	~qpol_mls_level_t() {
+	~qpol_mls_level() {
 		/* no op */
 		return;
 	};
-	const char *get_sens_name(qpol_policy_t *p) {
+	%rename(get_sens_name) wrap_get_sens_name;
+	const char *wrap_get_sens_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_mls_level_get_sens_name(p, self, &name)) {
@@ -1200,7 +1268,8 @@ typedef struct qpol_mls_level {} qpol_mls_level_t;
 		return name;
 	};
 	%newobject get_cat_iter(qpol_policy_t*);
-	qpol_iterator_t *get_cat_iter(qpol_policy_t *p) {
+	%rename(get_cat_iter) wrap_get_cat_iter;
+	qpol_iterator_t *wrap_get_cat_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_mls_level_get_cat_iter(p, self, &iter)) {
@@ -1220,7 +1289,7 @@ typedef struct qpol_mls_level {} qpol_mls_level_t;
 /* qpol user */
 typedef struct qpol_user {} qpol_user_t;
 %extend qpol_user_t {
-	qpol_user_t(qpol_policy_t *p, const char *name) {
+	qpol_user(qpol_policy_t *p, const char *name) {
 		const qpol_user_t *u;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_user_by_name(p, name, &u)) {
@@ -1231,11 +1300,12 @@ typedef struct qpol_user {} qpol_user_t;
 	fail:
 		return NULL;
 	};
-	~qpol_user_t() {
+	~qpol_user() {
 		/* no op */
 		return;
 	};
-	int get_value(qpol_policy_t *p) {
+	%rename(get_value) wrap_get_value;
+	int wrap_get_value(qpol_policy_t *p) {
 		uint32_t v;
 		BEGIN_EXCEPTION
 		if (qpol_user_get_value(p, self, &v)) {
@@ -1246,7 +1316,8 @@ typedef struct qpol_user {} qpol_user_t;
 		return (int) v;
 	};
 	%newobject get_role_iter(qpol_policy_t*);
-	qpol_iterator_t *get_role_iter(qpol_policy_t *p) {
+	%rename(get_role_iter) wrap_get_role_iter;
+	qpol_iterator_t *wrap_get_role_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_user_get_role_iter(p, self, &iter)) {
@@ -1256,7 +1327,8 @@ typedef struct qpol_user {} qpol_user_t;
 	fail:
 		return iter;
 	};
-	const qpol_mls_range_t *get_range(qpol_policy_t *p) {
+	%rename(get_range) wrap_get_range;
+	const qpol_mls_range_t *wrap_get_range(qpol_policy_t *p) {
 		const qpol_mls_range_t *r;
 		BEGIN_EXCEPTION
 		if (qpol_user_get_range(p, self, &r)) {
@@ -1266,7 +1338,8 @@ typedef struct qpol_user {} qpol_user_t;
 	fail:
 		return r;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_user_get_name(p, self, &name)) {
@@ -1276,7 +1349,8 @@ typedef struct qpol_user {} qpol_user_t;
 	fail:
 		return name;
 	};
-	const qpol_mls_level_t *get_dfltlevel(qpol_policy_t *p) {
+	%rename(get_dfltlevel) wrap_get_dfltlevel;
+	const qpol_mls_level_t *wrap_get_dfltlevel(qpol_policy_t *p) {
 		const qpol_mls_level_t *l;
 		BEGIN_EXCEPTION
 		if (qpol_user_get_dfltlevel(p, self, &l)) {
@@ -1296,7 +1370,7 @@ typedef struct qpol_user {} qpol_user_t;
 /* qpol bool */
 typedef struct qpol_bool {} qpol_bool_t;
 %extend qpol_bool_t {
-	qpol_bool_t(qpol_policy_t *p, const char *name) {
+	qpol_bool(qpol_policy_t *p, const char *name) {
 		qpol_bool_t *b;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_bool_by_name(p, name, &b)) {
@@ -1306,11 +1380,12 @@ typedef struct qpol_bool {} qpol_bool_t;
 	fail:
 		return b;
 	};
-	~qpol_bool_t() {
+	~qpol_bool() {
 		/* no op */
 		return;
 	};
-	int get_value(qpol_policy_t *p) {
+	%rename(get_value) wrap_get_value;
+	int wrap_get_value(qpol_policy_t *p) {
 		uint32_t v;
 		BEGIN_EXCEPTION
 		if (qpol_bool_get_value(p, self, &v)) {
@@ -1320,7 +1395,8 @@ typedef struct qpol_bool {} qpol_bool_t;
 	fail:
 		return (int) v;
 	};
-	int get_state(qpol_policy_t *p) {
+	%rename(get_state) wrap_get_state;
+	int wrap_get_state(qpol_policy_t *p) {
 		int s;
 		BEGIN_EXCEPTION
 		if (qpol_bool_get_state(p, self, &s)) {
@@ -1330,7 +1406,8 @@ typedef struct qpol_bool {} qpol_bool_t;
 	fail:
 		return s;
 	};
-	void set_state(qpol_policy_t *p, int state) {
+	%rename(set_state) wrap_set_state;
+	void wrap_set_state(qpol_policy_t *p, int state) {
 		BEGIN_EXCEPTION
 		if (qpol_bool_set_state(p, self, state)) {
 			SWIG_exception(SWIG_RuntimeError, "Error setting boolean state");
@@ -1339,7 +1416,8 @@ typedef struct qpol_bool {} qpol_bool_t;
 	fail:
 		return;
 	};
-	void set_state_no_eval(qpol_policy_t *p, int state) {
+	%rename(set_state_no_eval) wrap_set_state_no_eval;
+	void wrap_set_state_no_eval(qpol_policy_t *p, int state) {
 		BEGIN_EXCEPTION
 		if (qpol_bool_set_state_no_eval(p, self, state)) {
 			SWIG_exception(SWIG_RuntimeError, "Error setting boolean state");
@@ -1348,7 +1426,8 @@ typedef struct qpol_bool {} qpol_bool_t;
 	fail:
 		return;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_bool_get_name(p, self, &name)) {
@@ -1368,18 +1447,18 @@ typedef struct qpol_bool {} qpol_bool_t;
 /* qpol context */
 typedef struct qpol_context {} qpol_context_t;
 %extend qpol_context_t {
-	qpol_context_t() {
+	qpol_context() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_context_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_context_t() {
+	~qpol_context() {
 		/* no op */
 		return;
 	};
-	 const qpol_user_t *get_user(qpol_policy_t *p) {
+	 const qpol_user_t *wrap_get_user(qpol_policy_t *p) {
 		const qpol_user_t *u;
 		BEGIN_EXCEPTION
 		if (qpol_context_get_user(p, self, &u)) {
@@ -1389,7 +1468,7 @@ typedef struct qpol_context {} qpol_context_t;
 	fail:
 		return u;
 	 };
-	 const qpol_role_t *get_role(qpol_policy_t *p) {
+	 const qpol_role_t *wrap_get_role(qpol_policy_t *p) {
 		const qpol_role_t *r;
 		BEGIN_EXCEPTION
 		if (qpol_context_get_role(p, self, &r)) {
@@ -1399,7 +1478,7 @@ typedef struct qpol_context {} qpol_context_t;
 	fail:
 		return r;
 	 };
-	 const qpol_type_t *get_type(qpol_policy_t *p) {
+	 const qpol_type_t *wrap_get_type(qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_context_get_type(p, self, &t)) {
@@ -1409,7 +1488,7 @@ typedef struct qpol_context {} qpol_context_t;
 	fail:
 		return t;
 	 };
-	 const qpol_mls_range_t *get_range(qpol_policy_t *p) {
+	 const qpol_mls_range_t *wrap_get_range(qpol_policy_t *p) {
 		const qpol_mls_range_t *r;
 		BEGIN_EXCEPTION
 		if (qpol_context_get_range(p, self, &r)) {
@@ -1429,7 +1508,7 @@ typedef struct qpol_context {} qpol_context_t;
 /* qpol class */
 typedef struct qpol_class {} qpol_class_t;
 %extend qpol_class_t {
-	qpol_class_t(qpol_policy_t *p, const char *name) {
+	qpol_class(qpol_policy_t *p, const char *name) {
 		const qpol_class_t *c;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_class_by_name(p, name, &c)) {
@@ -1439,11 +1518,12 @@ typedef struct qpol_class {} qpol_class_t;
 	fail:
 		return (qpol_class_t*)c;
 	};
-	~qpol_class_t() {
+	~qpol_class() {
 		/* no op */
 		return;
 	};
-	int get_value(qpol_policy_t *p) {
+	%rename(get_value) wrap_get_value;
+	int wrap_get_value(qpol_policy_t *p) {
 		uint32_t v;
 		BEGIN_EXCEPTION
 		if (qpol_class_get_value(p, self, &v)) {
@@ -1453,7 +1533,8 @@ typedef struct qpol_class {} qpol_class_t;
 	fail:
 		return (int) v;
 	};
-	const qpol_common_t *get_common(qpol_policy_t *p) {
+	%rename(get_common) wrap_get_common;
+	const qpol_common_t *wrap_get_common(qpol_policy_t *p) {
 		const qpol_common_t *c;
 		BEGIN_EXCEPTION
 		if(qpol_class_get_common(p, self, &c)) {
@@ -1464,7 +1545,8 @@ typedef struct qpol_class {} qpol_class_t;
 		return c;
 	};
 	%newobject get_perm_iter(qpol_policy_t*);
-	qpol_iterator_t *get_perm_iter(qpol_policy_t *p) {
+	%rename(get_perm_iter) wrap_get_perm_iter;
+	qpol_iterator_t *wrap_get_perm_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if(qpol_class_get_perm_iter(p, self, &iter)) {
@@ -1475,7 +1557,8 @@ typedef struct qpol_class {} qpol_class_t;
 		return iter;
 	};
 	%newobject get_constraint_iter(qpol_policy_t*);
-	qpol_iterator_t *get_constraint_iter(qpol_policy_t *p) {
+	%rename(get_constraint_iter) wrap_get_constraint_iter;
+	qpol_iterator_t *wrap_get_constraint_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if(qpol_class_get_constraint_iter(p, self, &iter)) {
@@ -1486,7 +1569,8 @@ typedef struct qpol_class {} qpol_class_t;
 		return iter;
 	};
 	%newobject get_validatetrans_iter(qpol_policy_t*);
-	qpol_iterator_t *get_validatetrans_iter(qpol_policy_t *p) {
+	%rename(get_validatetrans_iter) wrap_get_validatetrans_iter;
+	qpol_iterator_t *wrap_get_validatetrans_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if(qpol_class_get_validatetrans_iter(p, self, &iter)) {
@@ -1496,7 +1580,8 @@ typedef struct qpol_class {} qpol_class_t;
 	fail:
 			return iter;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_class_get_name(p, self, &name)) {
@@ -1516,7 +1601,7 @@ typedef struct qpol_class {} qpol_class_t;
 /* qpol common */
 typedef struct qpol_common {} qpol_common_t;
 %extend qpol_common_t {
-	qpol_common_t(qpol_policy_t *p, const char *name) {
+	qpol_common(qpol_policy_t *p, const char *name) {
 		const qpol_common_t *c;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_common_by_name(p, name, &c)) {
@@ -1526,11 +1611,12 @@ typedef struct qpol_common {} qpol_common_t;
 	fail:
 		return (qpol_common_t*)c;
 	};
-	~qpol_common_t() {
+	~qpol_common() {
 		/* no op */
 		return;
 	};
-	int get_value(qpol_policy_t *p) {
+	%rename(get_value) wrap_get_value;
+	int wrap_get_value(qpol_policy_t *p) {
 		uint32_t v;
 		BEGIN_EXCEPTION
 		if (qpol_common_get_value(p, self, &v)) {
@@ -1541,7 +1627,8 @@ typedef struct qpol_common {} qpol_common_t;
 		return (int) v;
 	};
 	%newobject get_perm_iter(qpol_policy_t*);
-	qpol_iterator_t *get_perm_iter(qpol_policy_t *p) {
+	%rename(get_perm_iter) wrap_get_perm_iter;
+	qpol_iterator_t *wrap_get_perm_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if(qpol_common_get_perm_iter(p, self, &iter)) {
@@ -1551,7 +1638,8 @@ typedef struct qpol_common {} qpol_common_t;
 	fail:
 		return iter;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_common_get_name(p, self, &name)) {
@@ -1589,7 +1677,7 @@ typedef struct qpol_common {} qpol_common_t;
 #endif
 typedef struct qpol_fs_use {} qpol_fs_use_t;
 %extend qpol_fs_use_t {
-	qpol_fs_use_t(qpol_policy_t *p, const char *name) {
+	qpol_fs_use(qpol_policy_t *p, const char *name) {
 		const qpol_fs_use_t *f;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_fs_use_by_name(p, name, &f)) {
@@ -1599,11 +1687,12 @@ typedef struct qpol_fs_use {} qpol_fs_use_t;
 	fail:
 		return (qpol_fs_use_t*)f;
 	};
-	~qpol_fs_use_t() {
+	~qpol_fs_use() {
 		/* no op */
 		return;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_fs_use_get_name(p, self, &name)) {
@@ -1613,7 +1702,8 @@ typedef struct qpol_fs_use {} qpol_fs_use_t;
 	fail:
 		return name;
 	};
-	int get_behavior(qpol_policy_t *p) {
+	%rename(get_behavior) wrap_get_behavior;
+	int wrap_get_behavior(qpol_policy_t *p) {
 		uint32_t behav;
 		BEGIN_EXCEPTION
 		if (qpol_fs_use_get_behavior(p, self, &behav)) {
@@ -1623,7 +1713,8 @@ typedef struct qpol_fs_use {} qpol_fs_use_t;
 	fail:
 		return (int) behav;
 	};
-	const qpol_context_t *get_context(qpol_policy_t *p) {
+	%rename(get_context) wrap_get_context;
+	const qpol_context_t *wrap_get_context(qpol_policy_t *p) {
 		uint32_t behav;
 		const qpol_context_t *ctx = NULL;
 		BEGIN_EXCEPTION
@@ -1667,7 +1758,7 @@ typedef struct qpol_fs_use {} qpol_fs_use_t;
 #endif
 typedef struct qpol_genfscon {} qpol_genfscon_t;
 %extend qpol_genfscon_t {
-	qpol_genfscon_t(qpol_policy_t *p, const char *name, const char *path) {
+	qpol_genfscon(qpol_policy_t *p, const char *name, const char *path) {
 		qpol_genfscon_t *g;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_genfscon_by_name(p, name, path, &g)) {
@@ -1677,10 +1768,11 @@ typedef struct qpol_genfscon {} qpol_genfscon_t;
 	fail:
 		return g;
 	};
-	~qpol_genfscon_t() {
+	~qpol_genfscon() {
 		free(self);
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_genfscon_get_name(p, self, &name)) {
@@ -1690,7 +1782,8 @@ typedef struct qpol_genfscon {} qpol_genfscon_t;
 	fail:
 		return name;
 	};
-	const char *get_path(qpol_policy_t *p) {
+	%rename(get_path) wrap_get_path;
+	const char *wrap_get_path(qpol_policy_t *p) {
 		const char *path;
 		BEGIN_EXCEPTION
 		if (qpol_genfscon_get_path(p, self, &path)) {
@@ -1700,7 +1793,8 @@ typedef struct qpol_genfscon {} qpol_genfscon_t;
 	fail:
 		return path;
 	};
-	int get_class(qpol_policy_t *p) {
+	%rename(get_class) wrap_get_class;
+	int wrap_get_class(qpol_policy_t *p) {
 		uint32_t cls;
 		BEGIN_EXCEPTION
 		if (qpol_genfscon_get_class(p, self, &cls)) {
@@ -1710,7 +1804,8 @@ typedef struct qpol_genfscon {} qpol_genfscon_t;
 	fail:
 		return (int) cls;
 	};
-	const qpol_context_t *get_context(qpol_policy_t *p) {
+	%rename(get_context) wrap_get_context;
+	const qpol_context_t *wrap_get_context(qpol_policy_t *p) {
 		const qpol_context_t *ctx;
 		BEGIN_EXCEPTION
 		if (qpol_genfscon_get_context(p, self, &ctx)) {
@@ -1730,7 +1825,7 @@ typedef struct qpol_genfscon {} qpol_genfscon_t;
 /* qpol isid */
 typedef struct qpol_isid {} qpol_isid_t;
 %extend qpol_isid_t {
-	qpol_isid_t(qpol_policy_t *p, const char *name) {
+	qpol_isid(qpol_policy_t *p, const char *name) {
 		const qpol_isid_t *i;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_isid_by_name(p, name, &i)) {
@@ -1740,11 +1835,12 @@ typedef struct qpol_isid {} qpol_isid_t;
 	fail:
 		return (qpol_isid_t*)i;
 	};
-	~qpol_isid_t() {
+	~qpol_isid() {
 		/* no op */
 		return;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_isid_get_name(p, self, &name)) {
@@ -1754,7 +1850,8 @@ typedef struct qpol_isid {} qpol_isid_t;
 	fail:
 		return name;
 	};
-	const qpol_context_t *get_context(qpol_policy_t *p) {
+	%rename(get_context) wrap_get_context;
+	const qpol_context_t *wrap_get_context(qpol_policy_t *p) {
 		const qpol_context_t *ctx;
 		BEGIN_EXCEPTION
 		if (qpol_isid_get_context(p, self, &ctx)) {
@@ -1774,7 +1871,7 @@ typedef struct qpol_isid {} qpol_isid_t;
 /* qpol netifcon */
 typedef struct qpol_netifcon {} qpol_netifcon_t;
 %extend qpol_netifcon_t {
-	qpol_netifcon_t(qpol_policy_t *p, const char *name) {
+	qpol_netifcon(qpol_policy_t *p, const char *name) {
 		const qpol_netifcon_t *n;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_netifcon_by_name(p, name, &n)) {
@@ -1784,11 +1881,12 @@ typedef struct qpol_netifcon {} qpol_netifcon_t;
 	fail:
 		return (qpol_netifcon_t*)n;
 	};
-	~qpol_netifcon_t() {
+	~qpol_netifcon() {
 		/* no op */
 		return;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_netifcon_get_name(p, self, &name)) {
@@ -1798,7 +1896,8 @@ typedef struct qpol_netifcon {} qpol_netifcon_t;
 	fail:
 		return name;
 	};
-	const qpol_context_t *get_msg_con(qpol_policy_t *p) {
+	%rename(get_msg_con) wrap_get_msg_con;
+	const qpol_context_t *wrap_get_msg_con(qpol_policy_t *p) {
 		const qpol_context_t *ctx;
 		BEGIN_EXCEPTION
 		if (qpol_netifcon_get_msg_con(p, self, &ctx)) {
@@ -1808,7 +1907,8 @@ typedef struct qpol_netifcon {} qpol_netifcon_t;
 	fail:
 		return ctx;
 	};
-	const qpol_context_t *get_if_con(qpol_policy_t *p) {
+	%rename(get_if_con) wrap_get_if_con;
+	const qpol_context_t *wrap_get_if_con(qpol_policy_t *p) {
 		const qpol_context_t *ctx;
 		BEGIN_EXCEPTION
 		if (qpol_netifcon_get_if_con(p, self, &ctx)) {
@@ -1830,7 +1930,7 @@ typedef struct qpol_netifcon {} qpol_netifcon_t;
 #define QPOL_IPV6 1
 typedef struct qpol_nodecon {} qpol_nodecon_t;
 %extend qpol_nodecon_t {
-	qpol_nodecon_t(qpol_policy_t *p, int addr[4], int mask[4], int protocol) {
+	qpol_nodecon(qpol_policy_t *p, int addr[4], int mask[4], int protocol) {
 		uint32_t a[4], m[4];
 		qpol_nodecon_t *n;
 		BEGIN_EXCEPTION
@@ -1845,10 +1945,11 @@ typedef struct qpol_nodecon {} qpol_nodecon_t;
 	fail:
 		return n;
 	}
-	~qpol_nodecon_t() {
+	~qpol_nodecon() {
 		free(self);
 	};
-	uint32_t *get_addr(qpol_policy_t *p) {
+	%rename(get_addr) wrap_get_addr;
+	uint32_t *wrap_get_addr(qpol_policy_t *p) {
 		uint32_t *a;
 		BEGIN_EXCEPTION
 		unsigned char proto; /* currently dropped; stores the protocol - call get_protocol() */
@@ -1859,7 +1960,8 @@ typedef struct qpol_nodecon {} qpol_nodecon_t;
 	fail:
 		return a;
 	};
-	uint32_t *get_mask(qpol_policy_t *p) {
+	%rename(get_mask) wrap_get_mask;
+	uint32_t *wrap_get_mask(qpol_policy_t *p) {
 		uint32_t *m;
 		BEGIN_EXCEPTION
 		unsigned char proto; /* currently dropped; stores the protocol - call get_protocol() */
@@ -1870,7 +1972,8 @@ typedef struct qpol_nodecon {} qpol_nodecon_t;
 	fail:
 			return m;
 	};
-	int get_protocol(qpol_policy_t *p) {
+	%rename(get_protocol) wrap_get_protocol;
+	int wrap_get_protocol(qpol_policy_t *p) {
 		unsigned char proto;
 		BEGIN_EXCEPTION
 		if (qpol_nodecon_get_protocol(p, self, &proto)) {
@@ -1880,7 +1983,8 @@ typedef struct qpol_nodecon {} qpol_nodecon_t;
 	fail:
 		return proto;
 	};
-	const qpol_context_t *get_context(qpol_policy_t *p) {
+	%rename(get_context) wrap_get_context;
+	const qpol_context_t *wrap_get_context(qpol_policy_t *p) {
 		const qpol_context_t *ctx;
 		BEGIN_EXCEPTION
 		if (qpol_nodecon_get_context(p, self, &ctx)) {
@@ -1903,7 +2007,7 @@ typedef struct qpol_nodecon {} qpol_nodecon_t;
 #define IPPROTO_UDP 17
 typedef struct qpol_portcon {} qpol_portcon_t;
 %extend qpol_portcon_t {
-	qpol_portcon_t(qpol_policy_t *p, uint16_t low, uint16_t high, uint8_t protocol) {
+	qpol_portcon(qpol_policy_t *p, uint16_t low, uint16_t high, uint8_t protocol) {
 		const qpol_portcon_t *qp;
 		BEGIN_EXCEPTION
 		if (qpol_policy_get_portcon_by_port(p, low, high, protocol, &qp)) {
@@ -1913,11 +2017,12 @@ typedef struct qpol_portcon {} qpol_portcon_t;
 	fail:
 		return (qpol_portcon_t*)qp;
 	};
-	~qpol_portcon_t() {
+	~qpol_portcon() {
 		/* no op */
 		return;
 	};
-	uint16_t get_low_port(qpol_policy_t *p) {
+	%rename(get_low_port) wrap_get_low_port;
+	uint16_t wrap_get_low_port(qpol_policy_t *p) {
 		uint16_t port = 0;
 		BEGIN_EXCEPTION
 		if(qpol_portcon_get_low_port(p, self, &port)) {
@@ -1927,7 +2032,8 @@ typedef struct qpol_portcon {} qpol_portcon_t;
 	fail:
 		return port;
 	};
-	uint16_t get_high_port(qpol_policy_t *p) {
+	%rename(get_high_port) wrap_get_high_port;
+	uint16_t wrap_get_high_port(qpol_policy_t *p) {
 		uint16_t port = 0;
 		BEGIN_EXCEPTION
 		if(qpol_portcon_get_high_port(p, self, &port)) {
@@ -1937,7 +2043,8 @@ typedef struct qpol_portcon {} qpol_portcon_t;
 	fail:
 		return port;
 	};
-	uint8_t get_protocol(qpol_policy_t *p) {
+	%rename(get_protocol) wrap_get_protocol;
+	uint8_t wrap_get_protocol(qpol_policy_t *p) {
 		uint8_t proto = 0;
 		BEGIN_EXCEPTION
 		if (qpol_portcon_get_protocol(p, self, &proto)) {
@@ -1947,7 +2054,8 @@ typedef struct qpol_portcon {} qpol_portcon_t;
 	fail:
 		return proto;
 	};
-	const qpol_context_t *get_context(qpol_policy_t *p) {
+	%rename(get_context) wrap_get_context;
+	const qpol_context_t *wrap_get_context(qpol_policy_t *p) {
 		const qpol_context_t *ctx;
 		BEGIN_EXCEPTION
 		if (qpol_portcon_get_context(p, self, &ctx)) {
@@ -1967,17 +2075,18 @@ typedef struct qpol_portcon {} qpol_portcon_t;
 /* qpol constraint */
 typedef struct qpol_constraint {} qpol_constraint_t;
 %extend qpol_constraint_t {
-	qpol_constraint_t() {
+	qpol_constraint() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_constraint_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_constraint_t() {
+	~qpol_constraint() {
 		free(self);
 	};
-	const qpol_class_t *get_class(qpol_policy_t *p) {
+	%rename(get_class) wrap_get_class;
+	const qpol_class_t *wrap_get_class(qpol_policy_t *p) {
 		const qpol_class_t *cls;
 		BEGIN_EXCEPTION
 		if (qpol_constraint_get_class(p, self, &cls)) {
@@ -1988,7 +2097,8 @@ typedef struct qpol_constraint {} qpol_constraint_t;
 		return cls;
 	};
 	%newobject get_perm_iter(qpol_policy_t*);
-	qpol_iterator_t *get_perm_iter(qpol_policy_t *p) {
+	%rename(get_perm_iter) wrap_get_perm_iter;
+	qpol_iterator_t *wrap_get_perm_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_constraint_get_perm_iter(p, self, &iter)) {
@@ -1999,7 +2109,8 @@ typedef struct qpol_constraint {} qpol_constraint_t;
 		return iter;
 	};
 	%newobject get_expr_iter(qpol_policy_t*);
-	qpol_iterator_t *get_expr_iter(qpol_policy_t *p) {
+	%rename(get_expr_iter) wrap_get_expr_iter;
+	qpol_iterator_t *wrap_get_expr_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_constraint_get_expr_iter(p, self, &iter)) {
@@ -2019,17 +2130,18 @@ typedef struct qpol_constraint {} qpol_constraint_t;
 /* qpol validatetrans */
 typedef struct qpol_validatetrans {} qpol_validatetrans_t;
 %extend qpol_validatetrans_t {
-	qpol_validatetrans_t() {
+	qpol_validatetrans() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_validatetrans_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_validatetrans_t() {
+	~qpol_validatetrans() {
 		free(self);
 	};
-	const qpol_class_t *get_class(qpol_policy_t *p) {
+	%rename(get_class) wrap_get_class;
+	const qpol_class_t *wrap_get_class(qpol_policy_t *p) {
 		const qpol_class_t *cls;
 		BEGIN_EXCEPTION
 		if (qpol_validatetrans_get_class(p, self, &cls)) {
@@ -2040,7 +2152,8 @@ typedef struct qpol_validatetrans {} qpol_validatetrans_t;
 		return cls;
 	};
 	%newobject get_expr_iter(qpol_policy_t*);
-	qpol_iterator_t *get_expr_iter(qpol_policy_t *p) {
+	%rename(get_expr_iter) wrap_get_expr_iter;
+	qpol_iterator_t *wrap_get_expr_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_validatetrans_get_expr_iter(p, self, &iter)) {
@@ -2084,18 +2197,19 @@ typedef struct qpol_validatetrans {} qpol_validatetrans_t;
 #define QPOL_CEXPR_OP_INCOMP 5
 typedef struct qpol_constraint_expr_node {} qpol_constraint_expr_node_t;
 %extend qpol_constraint_expr_node_t {
-	qpol_constraint_expr_node_t() {
+	qpol_constraint_expr_node() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_constraint_expr_node_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_constraint_expr_node_t() {
+	~qpol_constraint_expr_node() {
 		/* no op */
 		return;
 	};
-	int get_expr_type(qpol_policy_t *p) {
+	%rename(get_expr_type) wrap_get_expr_type;
+	int wrap_get_expr_type(qpol_policy_t *p) {
 		uint32_t et;
 		BEGIN_EXCEPTION
 		if (qpol_constraint_expr_node_get_expr_type(p, self, &et)) {
@@ -2105,7 +2219,8 @@ typedef struct qpol_constraint_expr_node {} qpol_constraint_expr_node_t;
 	fail:
 		return (int) et;
 	};
-	int get_sym_type(qpol_policy_t *p) {
+	%rename(get_sym_type) wrap_get_sym_type;
+	int wrap_get_sym_type(qpol_policy_t *p) {
 		uint32_t st;
 		BEGIN_EXCEPTION
 		if (qpol_constraint_expr_node_get_sym_type(p, self, &st)) {
@@ -2115,7 +2230,8 @@ typedef struct qpol_constraint_expr_node {} qpol_constraint_expr_node_t;
 	fail:
 		return (int) st;
 	};
-	int get_op(qpol_policy_t *p) {
+	%rename(get_op) wrap_get_op;
+	int wrap_get_op(qpol_policy_t *p) {
 		uint32_t op;
 		BEGIN_EXCEPTION
 		if (qpol_constraint_expr_node_get_op(p, self, &op)) {
@@ -2126,7 +2242,8 @@ typedef struct qpol_constraint_expr_node {} qpol_constraint_expr_node_t;
 		return (int) op;
 	};
 	%newobject get_names_iter(qpol_policy_t*);
-	qpol_iterator_t *get_names_iter(qpol_policy_t *p) {
+	%rename(get_names_iter) wrap_get_names_iter;
+	qpol_iterator_t *wrap_get_names_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_constraint_expr_node_get_names_iter(p, self, &iter)) {
@@ -2146,18 +2263,19 @@ typedef struct qpol_constraint_expr_node {} qpol_constraint_expr_node_t;
 /* qpol role allow */
 typedef struct qpol_role_allow {} qpol_role_allow_t;
 %extend qpol_role_allow_t {
-	qpol_role_allow_t() {
+	qpol_role_allow() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_role_allow_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_role_allow_t() {
+	~qpol_role_allow() {
 		/* no op */
 		return;
 	};
-	const qpol_role_t *get_source_role(qpol_policy_t *p) {
+	%rename(get_source_role) wrap_get_source_role;
+	const qpol_role_t *wrap_get_source_role(qpol_policy_t *p) {
 		const qpol_role_t *r;
 		BEGIN_EXCEPTION
 		if (qpol_role_allow_get_source_role(p, self, &r)) {
@@ -2167,7 +2285,8 @@ typedef struct qpol_role_allow {} qpol_role_allow_t;
 	fail:
 		return r;
 	};
-	const qpol_role_t *get_target_role(qpol_policy_t *p) {
+	%rename(get_target_role) wrap_get_target_role;
+	const qpol_role_t *wrap_get_target_role(qpol_policy_t *p) {
 		const qpol_role_t *r;
 		BEGIN_EXCEPTION
 		if (qpol_role_allow_get_target_role(p, self, &r)) {
@@ -2187,18 +2306,19 @@ typedef struct qpol_role_allow {} qpol_role_allow_t;
 /* qpol role trans */
 typedef struct qpol_role_trans {} qpol_role_trans_t;
 %extend qpol_role_trans_t {
-	qpol_role_trans_t() {
+	qpol_role_trans() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_role_trans_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_role_trans_t() {
+	~qpol_role_trans() {
 		/* no op */
 		return;
 	};
-	const qpol_role_t *get_source_role(qpol_policy_t *p) {
+	%rename(get_source_role) wrap_get_source_role;
+	const qpol_role_t *wrap_get_source_role(qpol_policy_t *p) {
 		const qpol_role_t *r;
 		BEGIN_EXCEPTION
 		if (qpol_role_trans_get_source_role(p, self, &r)) {
@@ -2208,7 +2328,8 @@ typedef struct qpol_role_trans {} qpol_role_trans_t;
 	fail:
 		return r;
 	};
-	const qpol_type_t *get_target_type(qpol_policy_t *p) {
+	%rename(get_target_type) wrap_get_target_type;
+	const qpol_type_t *wrap_get_target_type(qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_role_trans_get_target_type(p, self, &t)) {
@@ -2218,7 +2339,8 @@ typedef struct qpol_role_trans {} qpol_role_trans_t;
 	fail:
 		return t;
 	};
-	const qpol_class_t *get_object_class(qpol_policy_t *p) {
+	%rename(get_object_class) wrap_get_object_class;
+	const qpol_class_t *wrap_get_object_class(qpol_policy_t *p) {
 		const qpol_class_t *c;
 		BEGIN_EXCEPTION
 		if (qpol_role_trans_get_object_class(p, self, &c)) {
@@ -2228,7 +2350,8 @@ typedef struct qpol_role_trans {} qpol_role_trans_t;
 	fail:
 		return c;
 	};
-	const qpol_role_t *get_default_role(qpol_policy_t *p) {
+	%rename(get_default_role) wrap_get_default_role;
+	const qpol_role_t *wrap_get_default_role(qpol_policy_t *p) {
 		const qpol_role_t *r;
 		BEGIN_EXCEPTION
 		if (qpol_role_trans_get_default_role(p, self, &r)) {
@@ -2248,18 +2371,19 @@ typedef struct qpol_role_trans {} qpol_role_trans_t;
 /* qpol range trans */
 typedef struct qpol_range_trans {} qpol_range_trans_t;
 %extend qpol_range_trans_t {
-	qpol_range_trans_t() {
+	qpol_range_trans() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_range_trans_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_range_trans_t() {
+	~qpol_range_trans() {
 		/* no op */
 		return;
 	};
-	const qpol_type_t *get_source_type (qpol_policy_t *p) {
+	%rename(get_source_type) wrap_get_source_type;
+	const qpol_type_t *wrap_get_source_type (qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_range_trans_get_source_type(p, self, &t)) {
@@ -2269,7 +2393,8 @@ typedef struct qpol_range_trans {} qpol_range_trans_t;
 	fail:
 		return t;
 	};
-	const qpol_type_t *get_target_type (qpol_policy_t *p) {
+	%rename(get_target_type) wrap_get_target_type;
+	const qpol_type_t *wrap_get_target_type (qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_range_trans_get_target_type(p, self, &t)) {
@@ -2278,7 +2403,8 @@ typedef struct qpol_range_trans {} qpol_range_trans_t;
 	fail:
 		return t;
 	};
-	const qpol_class_t *get_target_class(qpol_policy_t *p) {
+	%rename(get_target_class) wrap_get_target_class;
+	const qpol_class_t *wrap_get_target_class(qpol_policy_t *p) {
 		const qpol_class_t *cls;
 		BEGIN_EXCEPTION
 		if (qpol_range_trans_get_target_class(p, self, &cls)) {
@@ -2287,7 +2413,8 @@ typedef struct qpol_range_trans {} qpol_range_trans_t;
 	fail:
 		return cls;
 	};
-	const qpol_mls_range_t *get_range(qpol_policy_t *p) {
+	%rename(get_range) wrap_get_range;
+	const qpol_mls_range_t *wrap_get_range(qpol_policy_t *p) {
 		const qpol_mls_range_t *r;
 		BEGIN_EXCEPTION
 		if (qpol_range_trans_get_range(p, self, &r)) {
@@ -2311,18 +2438,19 @@ typedef struct qpol_range_trans {} qpol_range_trans_t;
 #define QPOL_RULE_DONTAUDIT     4
 typedef struct qpol_avrule {} qpol_avrule_t;
 %extend qpol_avrule_t {
-	qpol_avrule_t() {
+	qpol_avrule() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_avrule_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_avrule_t() {
+	~qpol_avrule() {
 		/* no op */
 		return;
 	};
-	int get_rule_type(qpol_policy_t *p) {
+	%rename(get_rule_type) wrap_get_rule_type;
+	int wrap_get_rule_type(qpol_policy_t *p) {
 		uint32_t rt;
 		BEGIN_EXCEPTION
 		if (qpol_avrule_get_rule_type(p, self, &rt)) {
@@ -2332,7 +2460,8 @@ typedef struct qpol_avrule {} qpol_avrule_t;
 	fail:
 		return (int) rt;
 	};
-	const qpol_type_t *get_source_type(qpol_policy_t *p) {
+	%rename(get_source_type) wrap_get_source_type;
+	const qpol_type_t *wrap_get_source_type(qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_avrule_get_source_type(p, self, &t)) {
@@ -2342,7 +2471,8 @@ typedef struct qpol_avrule {} qpol_avrule_t;
 	fail:
 		return t;
 	};
-	const qpol_type_t *get_target_type(qpol_policy_t *p) {
+	%rename(get_target_type) wrap_get_target_type;
+	const qpol_type_t *wrap_get_target_type(qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_avrule_get_target_type(p, self, &t)) {
@@ -2352,7 +2482,8 @@ typedef struct qpol_avrule {} qpol_avrule_t;
 	fail:
 		return t;
 	};
-	const qpol_class_t *get_object_class(qpol_policy_t *p) {
+	%rename(get_object_class) wrap_get_object_class;
+	const qpol_class_t *wrap_get_object_class(qpol_policy_t *p) {
 		const qpol_class_t *cls;
 		BEGIN_EXCEPTION
 		if (qpol_avrule_get_object_class(p, self, &cls)) {
@@ -2363,7 +2494,8 @@ typedef struct qpol_avrule {} qpol_avrule_t;
 		return cls;
 	};
 	%newobject get_perm_iter(qpol_policy_t *p);
-	qpol_iterator_t *get_perm_iter(qpol_policy_t *p) {
+	%rename(get_perm_iter) wrap_get_perm_iter;
+	qpol_iterator_t *wrap_get_perm_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_avrule_get_perm_iter(p, self, &iter)) {
@@ -2373,7 +2505,8 @@ typedef struct qpol_avrule {} qpol_avrule_t;
 	fail:
 		return iter;
 	};
-	const qpol_cond_t *get_cond(qpol_policy_t *p) {
+	%rename(get_cond) wrap_get_cond;
+	const qpol_cond_t *wrap_get_cond(qpol_policy_t *p) {
 		const qpol_cond_t *c;
 		BEGIN_EXCEPTION
 		if (qpol_avrule_get_cond(p, self, &c)) {
@@ -2383,7 +2516,8 @@ typedef struct qpol_avrule {} qpol_avrule_t;
 	fail:
 		return c;
 	};
-	int get_is_enabled(qpol_policy_t *p) {
+	%rename(get_is_enabled) wrap_get_is_enabled;
+	int wrap_get_is_enabled(qpol_policy_t *p) {
 		uint32_t e;
 		BEGIN_EXCEPTION
 		if (qpol_avrule_get_is_enabled(p, self, &e)) {
@@ -2393,7 +2527,8 @@ typedef struct qpol_avrule {} qpol_avrule_t;
 	fail:
 		return (int) e;
 	};
-	int get_which_list(qpol_policy_t *p) {
+	%rename(get_which_list) wrap_get_which_list;
+	int wrap_get_which_list(qpol_policy_t *p) {
 		const qpol_cond_t *c;
 		uint32_t which = 0;
 		BEGIN_EXCEPTION
@@ -2408,7 +2543,8 @@ typedef struct qpol_avrule {} qpol_avrule_t;
 		return (int) which;
 	};
 	%newobject get_syn_avrule_iter(qpol_policy_t*);
-	qpol_iterator_t *get_syn_avrule_iter(qpol_policy_t *p) {
+	%rename(get_syn_avrule_iter) wrap_get_syn_avrule_iter;
+	qpol_iterator_t *wrap_get_syn_avrule_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_avrule_get_syn_avrule_iter(p, self, &iter)) {
@@ -2431,18 +2567,19 @@ typedef struct qpol_avrule {} qpol_avrule_t;
 #define QPOL_RULE_TYPE_MEMBER  32
 typedef struct qpol_terule {} qpol_terule_t;
 %extend qpol_terule_t {
-	qpol_terule_t() {
+	qpol_terule() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_terule_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_terule_t() {
+	~qpol_terule() {
 		/* no op */
 		return;
 	};
-	int get_rule_type(qpol_policy_t *p) {
+	%rename(get_rule_type) wrap_get_rule_type;
+	int wrap_get_rule_type(qpol_policy_t *p) {
 		uint32_t rt;
 		BEGIN_EXCEPTION
 		if (qpol_terule_get_rule_type(p, self, &rt)) {
@@ -2452,7 +2589,8 @@ typedef struct qpol_terule {} qpol_terule_t;
 	fail:
 		return (int) rt;
 	};
-	const qpol_type_t *get_source_type(qpol_policy_t *p) {
+	%rename(get_source_type) wrap_get_source_type;
+	const qpol_type_t *wrap_get_source_type(qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_terule_get_source_type(p, self, &t)) {
@@ -2462,7 +2600,8 @@ typedef struct qpol_terule {} qpol_terule_t;
 	fail:
 		return t;
 	};
-	const qpol_type_t *get_target_type(qpol_policy_t *p) {
+	%rename(get_target_type) wrap_get_target_type;
+	const qpol_type_t *wrap_get_target_type(qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_terule_get_target_type(p, self, &t)) {
@@ -2472,7 +2611,8 @@ typedef struct qpol_terule {} qpol_terule_t;
 	fail:
 		return t;
 	};
-	const qpol_class_t *get_object_class(qpol_policy_t *p) {
+	%rename(get_object_class) wrap_get_object_class;
+	const qpol_class_t *wrap_get_object_class(qpol_policy_t *p) {
 		const qpol_class_t *cls;
 		BEGIN_EXCEPTION
 		if (qpol_terule_get_object_class(p, self, &cls)) {
@@ -2482,7 +2622,8 @@ typedef struct qpol_terule {} qpol_terule_t;
 	fail:
 		return cls;
 	};
-	const qpol_type_t *get_default_type(qpol_policy_t *p) {
+	%rename(get_default_type) wrap_get_default_type;
+	const qpol_type_t *wrap_get_default_type(qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_terule_get_default_type(p, self, &t)) {
@@ -2492,7 +2633,8 @@ typedef struct qpol_terule {} qpol_terule_t;
 	fail:
 		return t;
 	};
-	const qpol_cond_t *get_cond(qpol_policy_t *p) {
+	%rename(get_cond) wrap_get_cond;
+	const qpol_cond_t *wrap_get_cond(qpol_policy_t *p) {
 		const qpol_cond_t *c;
 		BEGIN_EXCEPTION
 		if (qpol_terule_get_cond(p, self, &c)) {
@@ -2502,7 +2644,8 @@ typedef struct qpol_terule {} qpol_terule_t;
 	fail:
 		return c;
 	};
-	int get_is_enabled(qpol_policy_t *p) {
+	%rename(get_is_enabled) wrap_get_is_enabled;
+	int wrap_get_is_enabled(qpol_policy_t *p) {
 		uint32_t e;
 		BEGIN_EXCEPTION
 		if (qpol_terule_get_is_enabled(p, self, &e)) {
@@ -2512,7 +2655,8 @@ typedef struct qpol_terule {} qpol_terule_t;
 	fail:
 		return (int) e;
 	};
-	int get_which_list(qpol_policy_t *p) {
+	%rename(get_which_list) wrap_get_which_list;
+	int wrap_get_which_list(qpol_policy_t *p) {
 		const qpol_cond_t *c;
 		uint32_t which = 0;
 		BEGIN_EXCEPTION
@@ -2527,7 +2671,8 @@ typedef struct qpol_terule {} qpol_terule_t;
 		return (int) which;
 	};
 	%newobject get_syn_terule_iter(qpol_policy_t*);
-	qpol_iterator_t *get_syn_terule_iter(qpol_policy_t *p) {
+	%rename(get_syn_terule_iter) wrap_get_syn_terule_iter;
+	qpol_iterator_t *wrap_get_syn_terule_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_terule_get_syn_terule_iter(p, self, &iter)) {
@@ -2547,19 +2692,20 @@ typedef struct qpol_terule {} qpol_terule_t;
 /* qpol conditional */
 typedef struct qpol_cond {} qpol_cond_t;
 %extend qpol_cond_t {
-	qpol_cond_t() {
+	qpol_cond() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_cond_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_cond_t() {
+	~qpol_cond() {
 		/* no op */
 		return;
 	};
 	%newobject get_expr_node_iter(qpol_policy_t*);
-	qpol_iterator_t *get_expr_node_iter(qpol_policy_t *p) {
+	%rename(get_expr_node_iter) wrap_get_expr_node_iter;
+	qpol_iterator_t *wrap_get_expr_node_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_cond_get_expr_node_iter(p, self, &iter)) {
@@ -2570,7 +2716,8 @@ typedef struct qpol_cond {} qpol_cond_t;
 		return iter;
 	};
 	%newobject get_av_true_iter(qpol_policy_t*, int);
-	qpol_iterator_t *get_av_true_iter(qpol_policy_t *p, int rule_types) {
+	%rename(get_av_true_iter) wrap_get_av_true_iter;
+	qpol_iterator_t *wrap_get_av_true_iter(qpol_policy_t *p, int rule_types) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_cond_get_av_true_iter(p, self, rule_types, &iter)) {
@@ -2581,7 +2728,8 @@ typedef struct qpol_cond {} qpol_cond_t;
 		return iter;
 	};
 	%newobject get_av_false_iter(qpol_policy_t*, int);
-	qpol_iterator_t *get_av_false_iter(qpol_policy_t *p, int rule_types) {
+	%rename(get_av_false_iter) wrap_get_av_false_iter;
+	qpol_iterator_t *wrap_get_av_false_iter(qpol_policy_t *p, int rule_types) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_cond_get_av_false_iter(p, self, rule_types, &iter)) {
@@ -2592,7 +2740,8 @@ typedef struct qpol_cond {} qpol_cond_t;
 		return iter;
 	};
 	%newobject get_te_true_iter(qpol_policy_t*, int);
-	qpol_iterator_t *get_te_true_iter(qpol_policy_t *p, int rule_types) {
+	%rename(get_te_true_iter) wrap_get_te_true_iter;
+	qpol_iterator_t *wrap_get_te_true_iter(qpol_policy_t *p, int rule_types) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_cond_get_te_true_iter(p, self, rule_types, &iter)) {
@@ -2603,7 +2752,8 @@ typedef struct qpol_cond {} qpol_cond_t;
 		return iter;
 	};
 	%newobject get_te_false_iter(qpol_policy_t*, int);
-	qpol_iterator_t *get_te_false_iter(qpol_policy_t *p, int rule_types) {
+	%rename(get_te_false_iter) wrap_get_te_false_iter;
+	qpol_iterator_t *wrap_get_te_false_iter(qpol_policy_t *p, int rule_types) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_cond_get_te_false_iter(p, self, rule_types, &iter)) {
@@ -2613,7 +2763,8 @@ typedef struct qpol_cond {} qpol_cond_t;
 	fail:
 			return iter;
 	};
-	int eval(qpol_policy_t *p) {
+	%rename(eval) wrap_eval;
+	int wrap_eval(qpol_policy_t *p) {
 		uint32_t e;
 		BEGIN_EXCEPTION
 		if (qpol_cond_eval(p, self, &e)) {
@@ -2640,18 +2791,19 @@ typedef struct qpol_cond {} qpol_cond_t;
 #define QPOL_COND_EXPR_NEQ  7      /* bool != bool */
 typedef struct qpol_cond_expr_node {} qpol_cond_expr_node_t;
 %extend qpol_cond_expr_node_t {
-	qpol_cond_expr_node_t() {
+	qpol_cond_expr_node() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_cond_expr_node_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_cond_expr_node_t() {
+	~qpol_cond_expr_node() {
 		/* no op */
 		return;
 	};
-	int get_expr_type(qpol_policy_t *p) {
+	%rename(get_expr_type) wrap_get_expr_type;
+	int wrap_get_expr_type(qpol_policy_t *p) {
 		uint32_t et;
 		BEGIN_EXCEPTION
 		if (qpol_cond_expr_node_get_expr_type(p, self, &et)) {
@@ -2661,7 +2813,8 @@ typedef struct qpol_cond_expr_node {} qpol_cond_expr_node_t;
 	fail:
 		return (int) et;
 	};
-	qpol_bool_t *get_bool(qpol_policy_t *p) {
+	%rename(get_bool) wrap_get_bool;
+	qpol_bool_t *wrap_get_bool(qpol_policy_t *p) {
 		uint32_t et;
 		qpol_bool_t *b = NULL;
 		BEGIN_EXCEPTION
@@ -2685,19 +2838,20 @@ typedef struct qpol_cond_expr_node {} qpol_cond_expr_node_t;
 /* qpol type set */
 typedef struct qpol_type_set {} qpol_type_set_t;
 %extend qpol_type_set_t {
-	qpol_type_set_t() {
+	qpol_type_set() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_type_set_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_type_set_t() {
+	~qpol_type_set() {
 		/* no op */
 		return;
 	};
 	%newobject get_included_types_iter(qpol_policy_t*);
-	qpol_iterator_t *get_included_types_iter(qpol_policy_t *p) {
+	%rename(get_included_types_iter) wrap_get_included_types_iter;
+	qpol_iterator_t *wrap_get_included_types_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_type_set_get_included_types_iter(p, self, &iter)) {
@@ -2708,7 +2862,8 @@ typedef struct qpol_type_set {} qpol_type_set_t;
 		return iter;
 	};
 	%newobject get_subtracted_types_iter(qpol_policy_t*);
-	qpol_iterator_t *get_subtracted_types_iter(qpol_policy_t *p) {
+	%rename(get_subtracted_types_iter) wrap_get_subtracted_types_iter;
+	qpol_iterator_t *wrap_get_subtracted_types_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_type_set_get_subtracted_types_iter(p, self, &iter)) {
@@ -2718,7 +2873,8 @@ typedef struct qpol_type_set {} qpol_type_set_t;
 	fail:
 		return iter;
 	};
-	int get_is_star(qpol_policy_t *p) {
+	%rename(get_is_star) wrap_get_is_star;
+	int wrap_get_is_star(qpol_policy_t *p) {
 		uint32_t s;
 		BEGIN_EXCEPTION
 		if (qpol_type_set_get_is_star(p, self, &s)) {
@@ -2728,7 +2884,8 @@ typedef struct qpol_type_set {} qpol_type_set_t;
 	fail:
 		return (int) s;
 	};
-	int get_is_comp(qpol_policy_t *p) {
+	%rename(get_is_comp) wrap_get_is_comp;
+	int wrap_get_is_comp(qpol_policy_t *p) {
 		uint32_t c;
 		BEGIN_EXCEPTION
 		if (qpol_type_set_get_is_comp(p, self, &c)) {
@@ -2748,18 +2905,19 @@ typedef struct qpol_type_set {} qpol_type_set_t;
 /* qpol syn av rule */
 typedef struct qpol_syn_avrule {} qpol_syn_avrule_t;
 %extend qpol_syn_avrule_t {
-	qpol_syn_avrule_t() {
+	qpol_syn_avrule() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_syn_avrule_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_syn_avrule_t() {
+	~qpol_syn_avrule() {
 		/* no op */
 		return;
 	};
-	int get_rule_type(qpol_policy_t *p) {
+	%rename(get_rule_type) wrap_get_rule_type;
+	int wrap_get_rule_type(qpol_policy_t *p) {
 		uint32_t rt;
 		BEGIN_EXCEPTION
 		if (qpol_syn_avrule_get_rule_type(p, self, &rt)) {
@@ -2769,7 +2927,8 @@ typedef struct qpol_syn_avrule {} qpol_syn_avrule_t;
 	fail:
 		return (int) rt;
 	};
-	const qpol_type_set_t *get_source_type_set(qpol_policy_t *p) {
+	%rename(get_source_type_set) wrap_get_source_type_set;
+	const qpol_type_set_t *wrap_get_source_type_set(qpol_policy_t *p) {
 		const qpol_type_set_t *ts;
 		BEGIN_EXCEPTION
 		if (qpol_syn_avrule_get_source_type_set(p, self, &ts)) {
@@ -2779,7 +2938,8 @@ typedef struct qpol_syn_avrule {} qpol_syn_avrule_t;
 	fail:
 		return ts;
 	};
-	const qpol_type_set_t *get_target_type_set(qpol_policy_t *p) {
+	%rename(get_target_type_set) wrap_get_target_type_set;
+	const qpol_type_set_t *wrap_get_target_type_set(qpol_policy_t *p) {
 		const qpol_type_set_t *ts;
 		BEGIN_EXCEPTION
 		if (qpol_syn_avrule_get_target_type_set(p, self, &ts)) {
@@ -2789,7 +2949,8 @@ typedef struct qpol_syn_avrule {} qpol_syn_avrule_t;
 	fail:
 		return ts;
 	};
-	int get_is_target_self(qpol_policy_t *p) {
+	%rename(get_is_target_self) wrap_get_is_target_self;
+	int wrap_get_is_target_self(qpol_policy_t *p) {
 		uint32_t i;
 		BEGIN_EXCEPTION
 		if (qpol_syn_avrule_get_is_target_self(p, self, &i)) {
@@ -2800,7 +2961,8 @@ typedef struct qpol_syn_avrule {} qpol_syn_avrule_t;
 		return (int) i;
 	};
 	%newobject get_class_iter(qpol_policy_t*);
-	qpol_iterator_t *get_class_iter(qpol_policy_t *p) {
+	%rename(get_class_iter) wrap_get_class_iter;
+	qpol_iterator_t *wrap_get_class_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_syn_avrule_get_class_iter(p, self, &iter)) {
@@ -2811,7 +2973,8 @@ typedef struct qpol_syn_avrule {} qpol_syn_avrule_t;
 		return iter;
 	};
 	%newobject get_perm_iter(qpol_policy_t*);
-	qpol_iterator_t *get_perm_iter(qpol_policy_t *p) {
+	%rename(get_perm_iter) wrap_get_perm_iter;
+	qpol_iterator_t *wrap_get_perm_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_syn_avrule_get_perm_iter(p, self, &iter)) {
@@ -2821,7 +2984,8 @@ typedef struct qpol_syn_avrule {} qpol_syn_avrule_t;
 	fail:
 		return iter;
 	};
-	long get_lineno(qpol_policy_t *p) {
+	%rename(get_lineno) wrap_get_lineno;
+	long wrap_get_lineno(qpol_policy_t *p) {
 		unsigned long l;
 		BEGIN_EXCEPTION
 		if (qpol_syn_avrule_get_lineno(p, self, &l)) {
@@ -2831,7 +2995,8 @@ typedef struct qpol_syn_avrule {} qpol_syn_avrule_t;
 	fail:
 		return (long)l;
 	};
-	const qpol_cond_t *get_cond(qpol_policy_t *p) {
+	%rename(get_cond) wrap_get_cond;
+	const qpol_cond_t *wrap_get_cond(qpol_policy_t *p) {
 		const qpol_cond_t *c;
 		BEGIN_EXCEPTION
 		if (qpol_syn_avrule_get_cond(p, self, &c)) {
@@ -2841,7 +3006,8 @@ typedef struct qpol_syn_avrule {} qpol_syn_avrule_t;
 	fail:
 		return c;
 	};
-	int get_is_enabled(qpol_policy_t *p) {
+	%rename(get_is_enabled) wrap_get_is_enabled;
+	int wrap_get_is_enabled(qpol_policy_t *p) {
 		uint32_t e;
 		BEGIN_EXCEPTION
 		if (qpol_syn_avrule_get_is_enabled(p, self, &e)) {
@@ -2861,18 +3027,19 @@ typedef struct qpol_syn_avrule {} qpol_syn_avrule_t;
 /* qpol syn te rule */
 typedef struct qpol_syn_terule {} qpol_syn_terule_t;
 %extend qpol_syn_terule_t {
-	qpol_syn_terule_t() {
+	qpol_syn_terule() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create qpol_syn_terule_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~qpol_syn_terule_t() {
+	~qpol_syn_terule() {
 		/* no op */
 		return;
 	};
-	int get_rule_type(qpol_policy_t *p) {
+	%rename(get_rule_type) wrap_get_rule_type;
+	int wrap_get_rule_type(qpol_policy_t *p) {
 		uint32_t rt;
 		BEGIN_EXCEPTION
 		if (qpol_syn_terule_get_rule_type(p, self, &rt)) {
@@ -2882,7 +3049,8 @@ typedef struct qpol_syn_terule {} qpol_syn_terule_t;
 	fail:
 		return rt;
 	};
-	const qpol_type_set_t *get_source_type_set(qpol_policy_t *p) {
+	%rename(get_source_type_set) wrap_get_source_type_set;
+	const qpol_type_set_t *wrap_get_source_type_set(qpol_policy_t *p) {
 		const qpol_type_set_t *ts;
 		BEGIN_EXCEPTION
 		if (qpol_syn_terule_get_source_type_set(p, self, &ts)) {
@@ -2892,7 +3060,8 @@ typedef struct qpol_syn_terule {} qpol_syn_terule_t;
 	fail:
 		return ts;
 	};
-	const qpol_type_set_t *get_target_type_set(qpol_policy_t *p) {
+	%rename(get_target_type_set) wrap_get_target_type_set;
+	const qpol_type_set_t *wrap_get_target_type_set(qpol_policy_t *p) {
 		const qpol_type_set_t *ts;
 		BEGIN_EXCEPTION
 		if (qpol_syn_terule_get_target_type_set(p, self, &ts)) {
@@ -2903,7 +3072,8 @@ typedef struct qpol_syn_terule {} qpol_syn_terule_t;
 		return ts;
 	};
 	%newobject get_class_iter(qpol_policy_t*);
-	qpol_iterator_t *get_class_iter(qpol_policy_t *p) {
+	%rename(get_class_iter) wrap_get_class_iter;
+	qpol_iterator_t *wrap_get_class_iter(qpol_policy_t *p) {
 		qpol_iterator_t *iter;
 		BEGIN_EXCEPTION
 		if (qpol_syn_terule_get_class_iter(p, self, &iter)) {
@@ -2913,7 +3083,8 @@ typedef struct qpol_syn_terule {} qpol_syn_terule_t;
 	fail:
 			return iter;
 	};
-	const qpol_type_t *get_default_type(qpol_policy_t *p) {
+	%rename(get_default_type) wrap_get_default_type;
+	const qpol_type_t *wrap_get_default_type(qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_syn_terule_get_default_type(p, self, &t)) {
@@ -2923,7 +3094,8 @@ typedef struct qpol_syn_terule {} qpol_syn_terule_t;
 	fail:
 		return t;
 	};
-	long get_lineno(qpol_policy_t *p) {
+	%rename(get_lineno) wrap_get_lineno;
+	long wrap_get_lineno(qpol_policy_t *p) {
 		unsigned long l;
 		BEGIN_EXCEPTION
 		if (qpol_syn_terule_get_lineno(p, self, &l)) {
@@ -2933,7 +3105,8 @@ typedef struct qpol_syn_terule {} qpol_syn_terule_t;
 	fail:
 		return (long)l;
 	};
-	const qpol_cond_t *get_cond(qpol_policy_t *p) {
+	%rename(get_cond) wrap_get_cond;
+	const qpol_cond_t *wrap_get_cond(qpol_policy_t *p) {
 		const qpol_cond_t *c;
 		BEGIN_EXCEPTION
 		if (qpol_syn_terule_get_cond(p, self, &c)) {
@@ -2943,7 +3116,8 @@ typedef struct qpol_syn_terule {} qpol_syn_terule_t;
 	fail:
 		return c;
 	};
-	int get_is_enabled(qpol_policy_t *p) {
+	%rename(get_is_enabled) wrap_get_is_enabled;
+	int wrap_get_is_enabled(qpol_policy_t *p) {
 		uint32_t e;
 		BEGIN_EXCEPTION
 		if (qpol_syn_terule_get_is_enabled(p, self, &e)) {
@@ -2974,7 +3148,8 @@ typedef struct qpol_filename_trans {} qpol_filename_trans_t;
 		/* no op */
 		return;
 	};
-	const qpol_type_t *get_source_type (qpol_policy_t *p) {
+	%rename(get_source_type) wrap_get_source_type;
+	const qpol_type_t *wrap_get_source_type (qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_filename_trans_get_source_type(p, self, &t)) {
@@ -2984,7 +3159,8 @@ typedef struct qpol_filename_trans {} qpol_filename_trans_t;
 	fail:
 		return t;
 	};
-	const qpol_type_t *get_target_type (qpol_policy_t *p) {
+	%rename(get_target_type) wrap_get_target_type;
+	const qpol_type_t *wrap_get_target_type (qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_filename_trans_get_target_type(p, self, &t)) {
@@ -2993,7 +3169,8 @@ typedef struct qpol_filename_trans {} qpol_filename_trans_t;
 	fail:
 		return t;
 	};
-	const qpol_class_t *get_object_class(qpol_policy_t *p) {
+	%rename(get_object_class) wrap_get_object_class;
+	const qpol_class_t *wrap_get_object_class(qpol_policy_t *p) {
 		const qpol_class_t *cls;
 		BEGIN_EXCEPTION
 		if (qpol_filename_trans_get_object_class(p, self, &cls)) {
@@ -3002,7 +3179,8 @@ typedef struct qpol_filename_trans {} qpol_filename_trans_t;
 	fail:
 		return cls;
 	};
-	const qpol_type_t *get_default_type(qpol_policy_t *p) {
+	%rename(get_default_type) wrap_get_default_type;
+	const qpol_type_t *wrap_get_default_type(qpol_policy_t *p) {
 		const qpol_type_t *t;
 		BEGIN_EXCEPTION
 		if (qpol_filename_trans_get_default_type(p, self, &t)) {
@@ -3012,7 +3190,8 @@ typedef struct qpol_filename_trans {} qpol_filename_trans_t;
 	fail:
 		return t;
 	};
-	const char *get_filename(qpol_policy_t *p) {
+	%rename(get_filename) wrap_get_filename;
+	const char *wrap_get_filename(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_filename_trans_get_filename(p, self, &name)) {
@@ -3044,7 +3223,8 @@ typedef struct qpol_polcap {} qpol_polcap_t;
 		/* no op */
 		return;
 	};
-	const char *get_name(qpol_policy_t *p) {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_polcap_get_name(p, self, &name)) {
@@ -3076,7 +3256,8 @@ typedef struct qpol_typebounds {} qpol_typebounds_t;
 		/* no op */
 		return;
 	};
-	const char *get_parent_name(qpol_policy_t *p) {
+	%rename(get_parent_name) wrap_get_parent_name;
+	const char *wrap_get_parent_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_typebounds_get_parent_name(p, self, &name)) {
@@ -3086,7 +3267,8 @@ typedef struct qpol_typebounds {} qpol_typebounds_t;
 	fail:
 		return name;
 	};
-	const char *get_child_name(qpol_policy_t *p) {
+	%rename(get_child_name) wrap_get_child_name;
+	const char *wrap_get_child_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_typebounds_get_child_name(p, self, &name)) {
@@ -3117,7 +3299,8 @@ typedef struct qpol_rolebounds {} qpol_rolebounds_t;
 		/* no op */
 		return;
 	};
-	const char *get_parent_name(qpol_policy_t *p) {
+	%rename(get_parent_name) wrap_get_parent_name;
+	const char *wrap_get_parent_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_rolebounds_get_parent_name(p, self, &name)) {
@@ -3127,7 +3310,8 @@ typedef struct qpol_rolebounds {} qpol_rolebounds_t;
 	fail:
 		return name;
 	};
-	const char *get_child_name(qpol_policy_t *p) {
+	%rename(get_child_name) wrap_get_child_name;
+	const char *wrap_get_child_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_rolebounds_get_child_name(p, self, &name)) {
@@ -3158,7 +3342,8 @@ typedef struct qpol_userbounds {} qpol_userbounds_t;
 		/* no op */
 		return;
 	};
-	const char *get_parent_name(qpol_policy_t *p) {
+	%rename(get_parent_name) wrap_get_parent_name;
+	const char *wrap_get_parent_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_userbounds_get_parent_name(p, self, &name)) {
@@ -3168,7 +3353,8 @@ typedef struct qpol_userbounds {} qpol_userbounds_t;
 	fail:
 		return name;
 	};
-	const char *get_child_name(qpol_policy_t *p) {
+	%rename(get_child_name) wrap_get_child_name;
+	const char *wrap_get_child_name(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_userbounds_get_child_name(p, self, &name)) {
@@ -3199,7 +3385,8 @@ typedef struct qpol_default_object {} qpol_default_object_t;
 		/* no op */
 		return;
 	};
-	const char *get_class(qpol_policy_t *p) {
+	%rename(get_class) wrap_get_class;
+	const char *wrap_get_class(qpol_policy_t *p) {
 		const char *name;
 		BEGIN_EXCEPTION
 		if (qpol_default_object_get_class(p, self, &name)) {
@@ -3209,7 +3396,8 @@ typedef struct qpol_default_object {} qpol_default_object_t;
 	fail:
 		return name;
 	};
-	const char *get_user_default(qpol_policy_t *p) {
+	%rename(get_user_default) wrap_get_user_default;
+	const char *wrap_get_user_default(qpol_policy_t *p) {
 		const char *value;
 		BEGIN_EXCEPTION
 		if (qpol_default_object_get_user_default(p, self, &value)) {
@@ -3219,7 +3407,8 @@ typedef struct qpol_default_object {} qpol_default_object_t;
 	fail:
 		return value;
 	};
-	const char *get_role_default(qpol_policy_t *p) {
+	%rename(get_role_default) wrap_get_role_default;
+	const char *wrap_get_role_default(qpol_policy_t *p) {
 		const char *value;
 		BEGIN_EXCEPTION
 		if (qpol_default_object_get_role_default(p, self, &value)) {
@@ -3229,7 +3418,8 @@ typedef struct qpol_default_object {} qpol_default_object_t;
 	fail:
 		return value;
 	};
-	const char *get_type_default(qpol_policy_t *p) {
+	%rename(get_type_default) wrap_get_type_default;
+	const char *wrap_get_type_default(qpol_policy_t *p) {
 		const char *value;
 		BEGIN_EXCEPTION
 		if (qpol_default_object_get_type_default(p, self, &value)) {
@@ -3239,7 +3429,8 @@ typedef struct qpol_default_object {} qpol_default_object_t;
 	fail:
 		return value;
 	};
-	const char *get_range_default(qpol_policy_t *p) {
+	%rename(get_range_default) wrap_get_range_default;
+	const char *wrap_get_range_default(qpol_policy_t *p) {
 		const char *value;
 		BEGIN_EXCEPTION
 		if (qpol_default_object_get_range_default(p, self, &value)) {

--- a/libseaudit/swig/seaudit.i
+++ b/libseaudit/swig/seaudit.i
@@ -252,7 +252,7 @@ typedef struct tm {
 	int tm_isdst; /* daylight saving time */
 } tm_t;
 %extend tm_t {
-	tm_t() {
+	tm() {
 		struct tm *t;
 		BEGIN_EXCEPTION
 		t = calloc(1, sizeof(struct tm));
@@ -263,7 +263,7 @@ typedef struct tm {
 	fail:
 		return t;
 	};
-	~tm_t() {
+	~tm() {
 		free(self);
 	}
 	/* use default accessor style for the rest */
@@ -280,7 +280,7 @@ typedef enum seaudit_log_type
 } seaudit_log_type_e;
 typedef struct seaudit_log {} seaudit_log_t;
 %extend seaudit_log_t {
-	seaudit_log_t() {
+	seaudit_log() {
 		seaudit_log_t *slog;
 		BEGIN_EXCEPTION
 		slog = seaudit_log_create(seaudit_swig_message_callback, seaudit_swig_message_callback_arg);
@@ -291,14 +291,16 @@ typedef struct seaudit_log {} seaudit_log_t;
 	fail:
 		return slog;
 	};
-	~seaudit_log_t() {
+	~seaudit_log() {
 		seaudit_log_destroy(&self);
 	};
-	void clear () {
+	%rename(clear) wrap_clear;
+	void wrap_clear () {
 		seaudit_log_clear(self);
 	};
 	%newobject get_users();
-	apol_string_vector_t *get_users() {
+	%rename(get_users) wrap_get_users;
+	apol_string_vector_t *wrap_get_users() {
 		apol_vector_t *v;
 		BEGIN_EXCEPTION
 		v = seaudit_log_get_users(self);
@@ -310,7 +312,8 @@ typedef struct seaudit_log {} seaudit_log_t;
 		return (apol_string_vector_t*)v;
 	};
 	%newobject get_roles();
-	apol_string_vector_t *get_roles() {
+	%rename(get_roles) wrap_get_roles;
+	apol_string_vector_t *wrap_get_roles() {
 		apol_vector_t *v;
 		BEGIN_EXCEPTION
 		v = seaudit_log_get_roles(self);
@@ -322,7 +325,8 @@ typedef struct seaudit_log {} seaudit_log_t;
 		return (apol_string_vector_t*)v;
 	};
 	%newobject get_types();
-	apol_string_vector_t *get_types() {
+	%rename(get_types) wrap_get_types;
+	apol_string_vector_t *wrap_get_types() {
 		apol_vector_t *v;
 		BEGIN_EXCEPTION
 		v = seaudit_log_get_types(self);
@@ -334,7 +338,8 @@ typedef struct seaudit_log {} seaudit_log_t;
 		return (apol_string_vector_t*)v;
 	};
 	%newobject get_classes();
-	apol_string_vector_t *get_classes() {
+	%rename(get_classes) wrap_get_classes;
+	apol_string_vector_t *wrap_get_classes() {
 		apol_vector_t *v;
 		BEGIN_EXCEPTION
 		v = seaudit_log_get_classes(self);
@@ -357,14 +362,14 @@ typedef enum seaudit_message_type
 } seaudit_message_type_e;
 typedef struct seaudit_message {} seaudit_message_t;
 %extend seaudit_message_t {
-	seaudit_message_t() {
+	seaudit_message() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Canot directly create seaudit_message_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~seaudit_message_t() {
+	~seaudit_message() {
 		/* no op */
 		return;
 	};
@@ -373,18 +378,22 @@ typedef struct seaudit_message {} seaudit_message_t;
 		(void)seaudit_message_get_data(self, &te);
 		return te;
 	};
-	void *get_data() {
+	%rename(get_data) wrap_get_data;
+	void *wrap_get_data() {
 		seaudit_message_type_e te;
 		return seaudit_message_get_data(self, &te);
 	};
-	const char *get_host() {
+	%rename(get_host) wrap_get_host;
+	const char *wrap_get_host() {
 		return seaudit_message_get_host(self);
 	};
-	const tm_t *get_time() {
+	%rename(get_time) wrap_get_time;
+	const tm_t *wrap_get_time() {
 		return seaudit_message_get_time(self);
 	}
 	%newobject to_string();
-	char *to_string() {
+	%rename(to_string) wrap_to_string;
+	char *wrap_to_string() {
 		char *str;
 		BEGIN_EXCEPTION
 		str = seaudit_message_to_string(self);
@@ -396,7 +405,8 @@ typedef struct seaudit_message {} seaudit_message_t;
 		return str;
 	};
 	%newobject to_string_html();
-	char *to_string_html() {
+	%rename(to_string_html) wrap_to_string_html;
+	char *wrap_to_string_html() {
 		char *str;
 		BEGIN_EXCEPTION
 		str = seaudit_message_to_string_html(self);
@@ -408,7 +418,8 @@ typedef struct seaudit_message {} seaudit_message_t;
 		return str;
 	};
 	%newobject to_misc_string();
-	char *to_misc_string() {
+	%rename(to_misc_string) wrap_to_misc_string;
+	char *wrap_to_misc_string() {
 		char *str;
 		BEGIN_EXCEPTION
 		str = seaudit_message_to_misc_string(self);
@@ -429,14 +440,14 @@ typedef struct seaudit_message {} seaudit_message_t;
 /* seaudit load message */
 typedef struct seaudit_load_message {} seaudit_load_message_t;
 %extend seaudit_load_message_t {
-	seaudit_load_message_t() {
+	seaudit_load_message() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create seaudit_load_message_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~seaudit_load_message_t() {
+	~seaudit_load_message() {
 		/* no op */
 		return;
 	};
@@ -450,14 +461,14 @@ typedef struct seaudit_load_message {} seaudit_load_message_t;
 /* seaudit bool message */
 typedef struct seaudit_bool_message {} seaudit_bool_message_t;
 %extend seaudit_bool_message_t {
-	seaudit_bool_message_t(void *msg) {
+	seaudit_bool_message(void *msg) {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create seaudit_bool_message_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~seaudit_bool_message_t() {
+	~seaudit_bool_message() {
 		/* no op */
 		return;
 	};
@@ -477,102 +488,131 @@ typedef enum seaudit_avc_message_type
 } seaudit_avc_message_type_e;
 typedef struct seaudit_avc_message {} seaudit_avc_message_t;
 %extend seaudit_avc_message_t {
-	seaudit_avc_message_t() {
+	seaudit_avc_message() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create seaudit_avc_message_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	~seaudit_avc_message_t() {
+	~seaudit_avc_message() {
 		/* no op */
 		return;
 	};
-	seaudit_avc_message_type_e get_message_type() {
+	%rename(get_message_type) wrap_get_message_type;
+	seaudit_avc_message_type_e wrap_get_message_type() {
 		return seaudit_avc_message_get_message_type(self);
 	};
-	long get_timestamp_nano() {
+	%rename(get_timestamp_nano) wrap_get_timestamp_nano;
+	long wrap_get_timestamp_nano() {
 		return seaudit_avc_message_get_timestamp_nano(self);
 	};
-	const char *get_source_user() {
+	%rename(get_source_user) wrap_get_source_user;
+	const char *wrap_get_source_user() {
 		return seaudit_avc_message_get_source_user(self);
 	};
-	const char *get_source_role() {
+	%rename(get_source_role) wrap_get_source_role;
+	const char *wrap_get_source_role() {
 		return seaudit_avc_message_get_source_role(self);
 	};
-	const char *get_source_type() {
+	%rename(get_source_type) wrap_get_source_type;
+	const char *wrap_get_source_type() {
 		return seaudit_avc_message_get_source_type(self);
 	};
-	const char *get_target_user() {
+	%rename(get_target_user) wrap_get_target_user;
+	const char *wrap_get_target_user() {
 		return seaudit_avc_message_get_target_user(self);
 	};
-	const char *get_target_role() {
+	%rename(get_target_role) wrap_get_target_role;
+	const char *wrap_get_target_role() {
 		return seaudit_avc_message_get_target_role(self);
 	};
-	const char *get_target_type() {
+	%rename(get_target_type) wrap_get_target_type;
+	const char *wrap_get_target_type() {
 		return seaudit_avc_message_get_target_type(self);
 	};
-	const char *get_object_class() {
+	%rename(get_object_class) wrap_get_object_class;
+	const char *wrap_get_object_class() {
 		return seaudit_avc_message_get_object_class(self);
 	};
-	const apol_string_vector_t *get_perm() {
+	%rename(get_perm) wrap_get_perm;
+	const apol_string_vector_t *wrap_get_perm() {
 		return (apol_string_vector_t*)seaudit_avc_message_get_perm(self);
 	};
-	const char *get_exe() {
+	%rename(get_exe) wrap_get_exe;
+	const char *wrap_get_exe() {
 		return seaudit_avc_message_get_exe(self);
 	};
-	const char *get_comm() {
+	%rename(get_comm) wrap_get_comm;
+	const char *wrap_get_comm() {
 		return seaudit_avc_message_get_comm(self);
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return seaudit_avc_message_get_name(self);
 	};
-	int get_pid() {
+	%rename(get_pid) wrap_get_pid;
+	int wrap_get_pid() {
 		return (int)seaudit_avc_message_get_pid(self);
 	};
-	long get_inode() {
+	%rename(get_inode) wrap_get_inode;
+	long wrap_get_inode() {
 		return (long)seaudit_avc_message_get_inode(self);
 	};
-	const char *get_path() {
+	%rename(get_path) wrap_get_path;
+	const char *wrap_get_path() {
 		return seaudit_avc_message_get_path(self);
 	};
-	const char *get_dev() {
+	%rename(get_dev) wrap_get_dev;
+	const char *wrap_get_dev() {
 		return seaudit_avc_message_get_dev(self);
 	};
-	const char *get_netif() {
+	%rename(get_netif) wrap_get_netif;
+	const char *wrap_get_netif() {
 		return seaudit_avc_message_get_netif(self);
 	};
-	int get_port() {
+	%rename(get_port) wrap_get_port;
+	int wrap_get_port() {
 		return seaudit_avc_message_get_port(self);
 	};
-	const char *get_laddr() {
+	%rename(get_laddr) wrap_get_laddr;
+	const char *wrap_get_laddr() {
 		return seaudit_avc_message_get_laddr(self);
 	};
-	int get_lport() {
+	%rename(get_lport) wrap_get_lport;
+	int wrap_get_lport() {
 		return seaudit_avc_message_get_lport(self);
 	};
-	const char *get_faddr() {
+	%rename(get_faddr) wrap_get_faddr;
+	const char *wrap_get_faddr() {
 		return seaudit_avc_message_get_faddr(self);
 	};
-	int get_fport() {
+	%rename(get_fport) wrap_get_fport;
+	int wrap_get_fport() {
 		return seaudit_avc_message_get_fport(self);
 	};
-	const char *get_saddr() {
+	%rename(get_saddr) wrap_get_saddr;
+	const char *wrap_get_saddr() {
 		return seaudit_avc_message_get_saddr(self);
 	};
-	int get_sport() {
+	%rename(get_sport) wrap_get_sport;
+	int wrap_get_sport() {
 		return seaudit_avc_message_get_sport(self);
 	};
-	const char *get_daddr() {
+	%rename(get_daddr) wrap_get_daddr;
+	const char *wrap_get_daddr() {
 		return seaudit_avc_message_get_daddr(self);
 	};
-	int get_dport() {
+	%rename(get_dport) wrap_get_dport;
+	int wrap_get_dport() {
 		return seaudit_avc_message_get_dport(self);
 	};
-	int get_key() {
+	%rename(get_key) wrap_get_key;
+	int wrap_get_key() {
 		return seaudit_avc_message_get_key(self);
 	};
-	int get_cap() {
+	%rename(get_cap) wrap_get_cap;
+	int wrap_get_cap() {
 		return seaudit_avc_message_get_cap(self);
 	};
 };
@@ -608,7 +648,7 @@ typedef enum seaudit_filter_date_match
 } seaudit_filter_date_match_e;
 typedef struct seaudit_filter {} seaudit_filter_t;
 %extend seaudit_filter_t {
-	seaudit_filter_t(char *name = NULL) {
+	seaudit_filter(char *name = NULL) {
 		seaudit_filter_t *sf = NULL;
 		BEGIN_EXCEPTION
 		sf = seaudit_filter_create(name);
@@ -619,7 +659,7 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return sf;
 	};
-	seaudit_filter_t(seaudit_filter_t *in) {
+	seaudit_filter(seaudit_filter_t *in) {
 		seaudit_filter_t *sf = NULL;
 		BEGIN_EXCEPTION
 		sf = seaudit_filter_create_from_filter(in);
@@ -630,7 +670,7 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return sf;
 	};
-	~seaudit_filter_t() {
+	~seaudit_filter() {
 		seaudit_filter_destroy(&self);
 	};
 	void save(char *path) {
@@ -642,7 +682,8 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	void set_match(seaudit_filter_match_e match) {
+	%rename(set_match) wrap_set_match;
+	void wrap_set_match(seaudit_filter_match_e match) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_match(self, match)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set filter matching method");
@@ -651,10 +692,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	}
-	seaudit_filter_match_e get_match() {
+	%rename(get_match) wrap_get_match;
+	seaudit_filter_match_e wrap_get_match() {
 		return seaudit_filter_get_match(self);
 	};
-	void set_name(char *name) {
+	%rename(set_name) wrap_set_name;
+	void wrap_set_name(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_name(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set filter name");
@@ -663,10 +706,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return seaudit_filter_get_name(self);
 	};
-	void set_description(char *description) {
+	%rename(set_description) wrap_set_description;
+	void wrap_set_description(char *description) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_description(self, description)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set filter description");
@@ -675,16 +720,20 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_description() {
+	%rename(get_description) wrap_get_description;
+	const char *wrap_get_description() {
 		return seaudit_filter_get_description(self);
 	};
-	void set_strict(bool is_strict) {
+	%rename(set_strict) wrap_set_strict;
+	void wrap_set_strict(bool is_strict) {
 		seaudit_filter_set_strict(self, is_strict);
 	};
-	bool get_strict() {
+	%rename(get_strict) wrap_get_strict;
+	bool wrap_get_strict() {
 		return seaudit_filter_get_strict(self);
 	};
-	void set_source_user(apol_string_vector_t *v) {
+	%rename(set_source_user) wrap_set_source_user;
+	void wrap_set_source_user(apol_string_vector_t *v) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_source_user(self, (apol_vector_t*)v)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set source user list for filter");
@@ -693,10 +742,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const apol_string_vector_t *get_source_user() {
+	%rename(get_source_user) wrap_get_source_user;
+	const apol_string_vector_t *wrap_get_source_user() {
 		return (apol_string_vector_t*)seaudit_filter_get_source_user(self);
 	};
-	void set_source_role(apol_string_vector_t *v) {
+	%rename(set_source_role) wrap_set_source_role;
+	void wrap_set_source_role(apol_string_vector_t *v) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_source_role(self, (apol_vector_t*)v)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set source role list for filter");
@@ -705,10 +756,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const apol_string_vector_t *get_source_role() {
+	%rename(get_source_role) wrap_get_source_role;
+	const apol_string_vector_t *wrap_get_source_role() {
 		return (apol_string_vector_t*)seaudit_filter_get_source_role(self);
 	};
-	void set_source_type(apol_string_vector_t *v) {
+	%rename(set_source_type) wrap_set_source_type;
+	void wrap_set_source_type(apol_string_vector_t *v) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_source_type(self, (apol_vector_t*)v)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set source type list for filter");
@@ -717,10 +770,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const apol_string_vector_t *get_source_type() {
+	%rename(get_source_type) wrap_get_source_type;
+	const apol_string_vector_t *wrap_get_source_type() {
 		return (apol_string_vector_t*)seaudit_filter_get_source_type(self);
 	};
-	void set_target_user(apol_string_vector_t *v) {
+	%rename(set_target_user) wrap_set_target_user;
+	void wrap_set_target_user(apol_string_vector_t *v) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_target_user(self, (apol_vector_t*)v)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set target user list for filter");
@@ -729,10 +784,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const apol_string_vector_t *get_target_user() {
+	%rename(get_target_user) wrap_get_target_user;
+	const apol_string_vector_t *wrap_get_target_user() {
 		return (apol_string_vector_t*)seaudit_filter_get_target_user(self);
 	};
-	void set_target_role(apol_string_vector_t *v) {
+	%rename(set_target_role) wrap_set_target_role;
+	void wrap_set_target_role(apol_string_vector_t *v) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_target_role(self, (apol_vector_t*)v)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set target role list for filter");
@@ -741,10 +798,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const apol_string_vector_t *get_target_role() {
+	%rename(get_target_role) wrap_get_target_role;
+	const apol_string_vector_t *wrap_get_target_role() {
 		return (apol_string_vector_t*)seaudit_filter_get_target_role(self);
 	};
-	void set_target_type(apol_string_vector_t *v) {
+	%rename(set_target_type) wrap_set_target_type;
+	void wrap_set_target_type(apol_string_vector_t *v) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_target_type(self, (apol_vector_t*)v)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set target type list for filter");
@@ -753,10 +812,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const apol_string_vector_t *get_target_type() {
+	%rename(get_target_type) wrap_get_target_type;
+	const apol_string_vector_t *wrap_get_target_type() {
 		return (apol_string_vector_t*)seaudit_filter_get_target_type(self);
 	};
-	void set_target_class(apol_string_vector_t *v) {
+	%rename(set_target_class) wrap_set_target_class;
+	void wrap_set_target_class(apol_string_vector_t *v) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_target_class(self, (apol_vector_t*)v)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set target class list for filter");
@@ -765,10 +826,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const apol_string_vector_t *get_target_class() {
+	%rename(get_target_class) wrap_get_target_class;
+	const apol_string_vector_t *wrap_get_target_class() {
 		return (apol_string_vector_t*)seaudit_filter_get_target_class(self);
 	};
-	void set_permission(char *name) {
+	%rename(set_permission) wrap_set_permission;
+	void wrap_set_permission(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_permission(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set permission for filter");
@@ -777,10 +840,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_permission() {
+	%rename(get_permission) wrap_get_permission;
+	const char *wrap_get_permission() {
 		return seaudit_filter_get_permission(self);
 	};
-	void set_executable(char *name) {
+	%rename(set_executable) wrap_set_executable;
+	void wrap_set_executable(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_executable(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set executable for filter");
@@ -789,10 +854,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_executable() {
+	%rename(get_executable) wrap_get_executable;
+	const char *wrap_get_executable() {
 		return seaudit_filter_get_executable(self);
 	};
-	void set_host(char *name) {
+	%rename(set_host) wrap_set_host;
+	void wrap_set_host(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_host(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set host for filter");
@@ -801,10 +868,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_host() {
+	%rename(get_host) wrap_get_host;
+	const char *wrap_get_host() {
 		return seaudit_filter_get_host(self);
 	};
-	void set_path(char *path) {
+	%rename(set_path) wrap_set_path;
+	void wrap_set_path(char *path) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_path(self, path)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set path for filter");
@@ -813,10 +882,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_path() {
+	%rename(get_path) wrap_get_path;
+	const char *wrap_get_path() {
 		return seaudit_filter_get_path(self);
 	};
-	void set_command(char *name) {
+	%rename(set_command) wrap_set_command;
+	void wrap_set_command(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_command(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set command for filter");
@@ -825,22 +896,28 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	void set_inode(long inode) {
+	%rename(set_inode) wrap_set_inode;
+	void wrap_set_inode(long inode) {
 		seaudit_filter_set_inode(self, (long) inode);
 	};
-	long get_inode() {
+	%rename(get_inode) wrap_get_inode;
+	long wrap_get_inode() {
 		return (long) seaudit_filter_get_inode(self);
 	};
-	void set_pid(long pid) {
+	%rename(set_pid) wrap_set_pid;
+	void wrap_set_pid(long pid) {
 		seaudit_filter_set_pid(self, (unsigned int) pid);
 	};
-	long get_pid() {
+	%rename(get_pid) wrap_get_pid;
+	long wrap_get_pid() {
 		return (long) seaudit_filter_get_pid(self);
 	};
-	const char *get_command() {
+	%rename(get_command) wrap_get_command;
+	const char *wrap_get_command() {
 		return seaudit_filter_get_command(self);
 	};
-	void set_anyaddr(char *name) {
+	%rename(set_anyaddr) wrap_set_anyaddr;
+	void wrap_set_anyaddr(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_anyaddr(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set ip address for filter");
@@ -849,16 +926,20 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_anyaddr() {
+	%rename(get_anyaddr) wrap_get_anyaddr;
+	const char *wrap_get_anyaddr() {
 		return seaudit_filter_get_anyaddr(self);
 	};
-	void set_anyport(int port) {
+	%rename(set_anyport) wrap_set_anyport;
+	void wrap_set_anyport(int port) {
 		seaudit_filter_set_anyport(self, port);
 	};
-	int get_anyport() {
+	%rename(get_anyport) wrap_get_anyport;
+	int wrap_get_anyport() {
 		return seaudit_filter_get_anyport(self);
 	};
-	void set_laddr(char *name) {
+	%rename(set_laddr) wrap_set_laddr;
+	void wrap_set_laddr(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_laddr(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set local address for filter");
@@ -867,16 +948,20 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_laddr() {
+	%rename(get_laddr) wrap_get_laddr;
+	const char *wrap_get_laddr() {
 		return seaudit_filter_get_laddr(self);
 	};
-	void set_lport(int port) {
+	%rename(set_lport) wrap_set_lport;
+	void wrap_set_lport(int port) {
 		seaudit_filter_set_lport(self, port);
 	};
-	int get_lport() {
+	%rename(get_lport) wrap_get_lport;
+	int wrap_get_lport() {
 		return seaudit_filter_get_lport(self);
 	};
-	void set_faddr(char *name) {
+	%rename(set_faddr) wrap_set_faddr;
+	void wrap_set_faddr(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_faddr(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set foreign address for filter");
@@ -885,16 +970,20 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_faddr() {
+	%rename(get_faddr) wrap_get_faddr;
+	const char *wrap_get_faddr() {
 		return seaudit_filter_get_faddr(self);
 	};
-	void set_fport(int port) {
+	%rename(set_fport) wrap_set_fport;
+	void wrap_set_fport(int port) {
 		seaudit_filter_set_fport(self, port);
 	};
-	int get_fport() {
+	%rename(get_fport) wrap_get_fport;
+	int wrap_get_fport() {
 		return seaudit_filter_get_fport(self);
 	};
-	void set_saddr(char *name) {
+	%rename(set_saddr) wrap_set_saddr;
+	void wrap_set_saddr(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_saddr(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set source address for filter");
@@ -903,16 +992,20 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_saddr() {
+	%rename(get_saddr) wrap_get_saddr;
+	const char *wrap_get_saddr() {
 		return seaudit_filter_get_saddr(self);
 	};
-	void set_sport(int port) {
+	%rename(set_sport) wrap_set_sport;
+	void wrap_set_sport(int port) {
 		seaudit_filter_set_sport(self, port);
 	};
-	int get_sport() {
+	%rename(get_sport) wrap_get_sport;
+	int wrap_get_sport() {
 		return seaudit_filter_get_sport(self);
 	};
-	void set_daddr(char *name) {
+	%rename(set_daddr) wrap_set_daddr;
+	void wrap_set_daddr(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_daddr(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set destination address for filter");
@@ -921,22 +1014,28 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_daddr() {
+	%rename(get_daddr) wrap_get_daddr;
+	const char *wrap_get_daddr() {
 		return seaudit_filter_get_daddr(self);
 	};
-	void set_dport(int port) {
+	%rename(set_dport) wrap_set_dport;
+	void wrap_set_dport(int port) {
 		seaudit_filter_set_dport(self, port);
 	};
-	int get_dport() {
+	%rename(get_dport) wrap_get_dport;
+	int wrap_get_dport() {
 		return seaudit_filter_get_dport(self);
 	};
-	void set_port(int port) {
+	%rename(set_port) wrap_set_port;
+	void wrap_set_port(int port) {
 		seaudit_filter_set_port(self, port);
 	};
-	int get_port() {
+	%rename(get_port) wrap_get_port;
+	int wrap_get_port() {
 		return seaudit_filter_get_port(self);
 	};
-	void set_netif(char *name) {
+	%rename(set_netif) wrap_set_netif;
+	void wrap_set_netif(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_netif(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set network interface for filter");
@@ -945,22 +1044,28 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	const char *get_netif() {
+	%rename(get_netif) wrap_get_netif;
+	const char *wrap_get_netif() {
 		return seaudit_filter_get_netif(self);
 	};
-	void set_key(int key) {
+	%rename(set_key) wrap_set_key;
+	void wrap_set_key(int key) {
 		seaudit_filter_set_key(self, key);
 	};
-	int get_key() {
+	%rename(get_key) wrap_get_key;
+	int wrap_get_key() {
 		return seaudit_filter_get_key(self);
 	};
-	void set_cap(int cap) {
+	%rename(set_cap) wrap_set_cap;
+	void wrap_set_cap(int cap) {
 		seaudit_filter_set_cap(self, cap);
 	};
-	int get_cap() {
+	%rename(get_cap) wrap_get_cap;
+	int wrap_get_cap() {
 		return seaudit_filter_get_cap(self);
 	};
-	void set_message_type(seaudit_avc_message_type_e mtype) {
+	%rename(set_message_type) wrap_set_message_type;
+	void wrap_set_message_type(seaudit_avc_message_type_e mtype) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_message_type(self, mtype)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set message type for filter");
@@ -969,10 +1074,12 @@ typedef struct seaudit_filter {} seaudit_filter_t;
 	fail:
 		return;
 	};
-	seaudit_message_type_e get_message_type() {
+	%rename(get_message_type) wrap_get_message_type;
+	seaudit_message_type_e wrap_get_message_type() {
 		return seaudit_filter_get_message_type(self);
 	};
-	void set_date(struct tm *start, struct tm *end, seaudit_filter_date_match_e match) {
+	%rename(set_date) wrap_set_date;
+	void wrap_set_date(struct tm *start, struct tm *end, seaudit_filter_date_match_e match) {
 		BEGIN_EXCEPTION
 		if (seaudit_filter_set_date(self, start, end, match)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set date for filter");
@@ -1014,14 +1121,14 @@ apol_vector_t *seaudit_filter_create_from_file(const char *filename);
 /* seaudit sort */
 typedef struct seaudit_sort {} seaudit_sort_t;
 %extend seaudit_sort_t {
-	seaudit_sort_t() {
+	seaudit_sort() {
 		BEGIN_EXCEPTION
 		SWIG_exception(SWIG_RuntimeError, "Cannot directly create seaudit_sort_t objects");
 		END_EXCEPTION
 	fail:
 		return NULL;
 	};
-	seaudit_sort_t(seaudit_sort_t *in) {
+	seaudit_sort(seaudit_sort_t *in) {
 		seaudit_sort_t *ss = NULL;
 		BEGIN_EXCEPTION
 		ss = seaudit_sort_create_from_sort(in);
@@ -1032,7 +1139,7 @@ typedef struct seaudit_sort {} seaudit_sort_t;
 	fail:
 		return ss;
 	};
-        ~seaudit_sort_t() {
+        ~seaudit_sort() {
 		seaudit_sort_destroy(&self);
 	};
 };
@@ -1113,7 +1220,7 @@ extern seaudit_sort_t *seaudit_sort_by_cap(const int direction);
 #endif
 typedef struct seaudit_model {} seaudit_model_t;
 %extend seaudit_model_t {
-	seaudit_model_t(char *name = NULL, seaudit_log_t *slog = NULL) {
+	seaudit_model(char *name = NULL, seaudit_log_t *slog = NULL) {
 		seaudit_model_t *smod;
 		BEGIN_EXCEPTION
 		smod = seaudit_model_create(name, slog);
@@ -1124,7 +1231,7 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return smod;
 	};
-	seaudit_model_t(seaudit_model_t *in) {
+	seaudit_model(seaudit_model_t *in) {
 		seaudit_model_t *smod;
 		BEGIN_EXCEPTION
 		smod = seaudit_model_create_from_model(in);
@@ -1135,7 +1242,7 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return smod;
 	};
-	seaudit_model_t(char *path) {
+	seaudit_model(char *path) {
 		seaudit_model_t *smod;
 		BEGIN_EXCEPTION
 		smod = seaudit_model_create_from_file(path);
@@ -1146,7 +1253,7 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return smod;
 	}
-	~seaudit_model_t() {
+	~seaudit_model() {
 		seaudit_model_destroy(&self);
 	};
 	void save(char *path) {
@@ -1158,10 +1265,12 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return;
 	}
-	const char *get_name() {
+	%rename(get_name) wrap_get_name;
+	const char *wrap_get_name() {
 		return seaudit_model_get_name(self);
 	};
-	void set_name(char *name) {
+	%rename(set_name) wrap_set_name;
+	void wrap_set_name(char *name) {
 		BEGIN_EXCEPTION
 		if (seaudit_model_set_name(self, name)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set model name");
@@ -1170,7 +1279,8 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return;
 	};
-	void append_log(seaudit_log_t *slog) {
+	%rename(append_log) wrap_append_log;
+	void wrap_append_log(seaudit_log_t *slog) {
 		BEGIN_EXCEPTION
 		if (seaudit_model_append_log(self, slog)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not append log to model");
@@ -1179,7 +1289,8 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return;
 	};
-	void append_filter(seaudit_filter_t *filter) {
+	%rename(append_filter) wrap_append_filter;
+	void wrap_append_filter(seaudit_filter_t *filter) {
 		BEGIN_EXCEPTION
 #ifdef SWIGJAVA /* duplicate so the garbage collector does not double free */
 		seaudit_filter_t *tmp = seaudit_filter_create_from_filter(filter);
@@ -1196,11 +1307,13 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return;
 	};
-	const apol_vector_t *get_filters() {
+	%rename(get_filters) wrap_get_filters;
+	const apol_vector_t *wrap_get_filters() {
 		return seaudit_model_get_filters(self);
 	};
 	%delobject remove_filter();
-	void remove_filter(seaudit_filter_t *filter) {
+	%rename(remove_filter) wrap_remove_filter;
+	void wrap_remove_filter(seaudit_filter_t *filter) {
 		BEGIN_EXCEPTION
 		if (seaudit_model_remove_filter(self, filter)) {
 			SWIG_exception(SWIG_ValueError, "Could not remove filter");
@@ -1209,7 +1322,8 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return;
 	};
-	void set_filter_match(seaudit_filter_match_e match) {
+	%rename(set_filter_match) wrap_set_filter_match;
+	void wrap_set_filter_match(seaudit_filter_match_e match) {
 		BEGIN_EXCEPTION
 		if (seaudit_model_set_filter_match(self, match)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set filter matching method for model");
@@ -1218,10 +1332,12 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return;
 	};
-	seaudit_filter_match_e get_filter_match() {
+	%rename(get_filter_match) wrap_get_filter_match;
+	seaudit_filter_match_e wrap_get_filter_match() {
 		return seaudit_model_get_filter_match(self);
 	};
-	void set_filter_visible(seaudit_filter_visible_e vis) {
+	%rename(set_filter_visible) wrap_set_filter_visible;
+	void wrap_set_filter_visible(seaudit_filter_visible_e vis) {
 		BEGIN_EXCEPTION
 		if (seaudit_model_set_filter_visible(self, vis)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set filter visibility for model");
@@ -1230,10 +1346,12 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return;
 	};
-	seaudit_filter_visible_e get_filter_visible() {
+	%rename(get_filter_visible) wrap_get_filter_visible;
+	seaudit_filter_visible_e wrap_get_filter_visible() {
 		return seaudit_model_get_filter_visible(self);
 	};
-	void append_sort(seaudit_sort_t *ssort) {
+	%rename(append_sort) wrap_append_sort;
+	void wrap_append_sort(seaudit_sort_t *ssort) {
 		BEGIN_EXCEPTION
 #ifdef SWIGJAVA
 		seaudit_sort_t *tmp = seaudit_sort_create_from_sort(ssort);
@@ -1250,7 +1368,8 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return;
 	};
-	void clear_sorts() {
+	%rename(clear_sorts) wrap_clear_sorts;
+	void wrap_clear_sorts() {
 		BEGIN_EXCEPTION
 		if (seaudit_model_clear_sorts(self)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not clear model sorting criteria");
@@ -1259,11 +1378,13 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return;
 	};
-	int is_changed() {
+	%rename(is_changed) wrap_is_changed;
+	int wrap_is_changed() {
 		return seaudit_model_is_changed(self);
 	};
 	%newobject get_messages(seaudit_log_t*);
-	apol_vector_t *get_messages(seaudit_log_t *slog) {
+	%rename(get_messages) wrap_get_messages;
+	apol_vector_t *wrap_get_messages(seaudit_log_t *slog) {
 		apol_vector_t *v = NULL;
 		BEGIN_EXCEPTION
 		v = seaudit_model_get_messages(slog, self);
@@ -1275,7 +1396,8 @@ typedef struct seaudit_model {} seaudit_model_t;
 		return v;
 	};
 	%newobject get_malformed_messages(seaudit_log_t*);
-	apol_vector_t *get_malformed_messages(seaudit_log_t *slog) {
+	%rename(get_malformed_messages) wrap_get_malformed_messages;
+	apol_vector_t *wrap_get_malformed_messages(seaudit_log_t *slog) {
 		apol_vector_t *v = NULL;
 		BEGIN_EXCEPTION
 		v = seaudit_model_get_malformed_messages(slog, self);
@@ -1286,19 +1408,24 @@ typedef struct seaudit_model {} seaudit_model_t;
 	fail:
 		return v;
 	};
-	void hide_message(seaudit_message_t *message) {
+	%rename(hide_message) wrap_hide_message;
+	void wrap_hide_message(seaudit_message_t *message) {
 		seaudit_model_hide_message(self, message);
 	};
-	size_t get_num_allows(seaudit_log_t *slog) {
+	%rename(get_num_allows) wrap_get_num_allows;
+	size_t wrap_get_num_allows(seaudit_log_t *slog) {
 		return seaudit_model_get_num_allows(slog, self);
 	};
-	size_t get_num_denies(seaudit_log_t *slog) {
+	%rename(get_num_denies) wrap_get_num_denies;
+	size_t wrap_get_num_denies(seaudit_log_t *slog) {
 		return seaudit_model_get_num_denies(slog, self);
 	};
-	size_t get_num_bools(seaudit_log_t *slog) {
+	%rename(get_num_bools) wrap_get_num_bools;
+	size_t wrap_get_num_bools(seaudit_log_t *slog) {
 		return seaudit_model_get_num_bools(slog, self);
 	};
-	size_t get_num_loads(seaudit_log_t *slog) {
+	%rename(get_num_loads) wrap_get_num_loads;
+	size_t wrap_get_num_loads(seaudit_log_t *slog) {
 		return seaudit_model_get_num_loads(slog, self);
 	};
 };
@@ -1311,7 +1438,7 @@ typedef enum seaudit_report_format
 } seaudit_report_format_e;
 typedef struct seaudit_report {} seaudit_report_t;
 %extend seaudit_report_t {
-	seaudit_report_t(seaudit_model_t *m) {
+	seaudit_report(seaudit_model_t *m) {
 		seaudit_report_t *sr;
 		BEGIN_EXCEPTION
 		sr = seaudit_report_create(m);
@@ -1322,10 +1449,11 @@ typedef struct seaudit_report {} seaudit_report_t;
 	fail:
 		return sr;
 	};
-	~seaudit_report_t() {
+	~seaudit_report() {
 		seaudit_report_destroy(&self);
 	};
-	void write(seaudit_log_t *slog, char *path) {
+	%rename(write) wrap_write;
+	void wrap_write(seaudit_log_t *slog, char *path) {
 		BEGIN_EXCEPTION
 		if (seaudit_report_write(slog, self, path)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not write report to file");
@@ -1334,7 +1462,8 @@ typedef struct seaudit_report {} seaudit_report_t;
 	fail:
 		return;
 	};
-	void set_format(seaudit_log_t *slog, seaudit_report_format_e format) {
+	%rename(set_format) wrap_set_format;
+	void wrap_set_format(seaudit_log_t *slog, seaudit_report_format_e format) {
 		BEGIN_EXCEPTION
 		if (seaudit_report_set_format(slog, self, format)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set report format");
@@ -1343,7 +1472,8 @@ typedef struct seaudit_report {} seaudit_report_t;
 	fail:
 		return;
 	};
-	void set_configuration(seaudit_log_t *slog, char *path) {
+	%rename(set_configuration) wrap_set_configuration;
+	void wrap_set_configuration(seaudit_log_t *slog, char *path) {
 		BEGIN_EXCEPTION
 		if (seaudit_report_set_configuration(slog, self, path)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set report configuration file");
@@ -1352,7 +1482,8 @@ typedef struct seaudit_report {} seaudit_report_t;
 	fail:
 		return;
 	};
-	void set_stylesheet(seaudit_log_t *slog, char *path, int use_stylesheet) {
+	%rename(set_stylesheet) wrap_set_stylesheet;
+	void wrap_set_stylesheet(seaudit_log_t *slog, char *path, int use_stylesheet) {
 		BEGIN_EXCEPTION
 		if (seaudit_report_set_stylesheet(slog, self, path, use_stylesheet)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set report stylesheet");
@@ -1361,7 +1492,8 @@ typedef struct seaudit_report {} seaudit_report_t;
 	fail:
 		return;
 	};
-	void set_malformed(seaudit_log_t *slog, int do_malformed) {
+	%rename(set_malformed) wrap_set_malformed;
+	void wrap_set_malformed(seaudit_log_t *slog, int do_malformed) {
 		BEGIN_EXCEPTION
 		if (seaudit_report_set_malformed(slog, self, do_malformed)) {
 			SWIG_exception(SWIG_RuntimeError, "Could not set report malformed flag");


### PR DESCRIPTION
Hi,

This patch makes it possible to use SWIG 3 to build setools 3.3.8 without changing the API. A large part comes from @sjvermeu work on https://bugs.gentoo.org/show_bug.cgi?id=430262 (http://dev.gentoo.org/~swift/patches/0008-fix_swig_build_failures_bug_430262.patch) a few years ago.

To be able to build setools on Arch Linux with libsepol 2.4, I also:
* backported https://github.com/TresysTechnology/setools/commit/3937946900cf4f8bee2fdda697831b14ab8f849d
* replaced ``replcon_lsetfilecon`` by ``lsetfilecon_raw`` in secmds/replcon.cc (cf. http://marc.info/?l=selinux&m=140129722008136&w=2)
* replaced ``AC_PROG_SWIG(2.0.0)`` with ``AC_PROG_SWIG`` in configure.ac.

With this, I successfully built, installed, loaded and used a policy.

I mostly tested the result when building with SWIG 3.0.5. I tested building with SWIG 2.0.12 (also available on Arch Linux) and the patch makes it work fine.

Cheers